### PR TITLE
Fix border display of table header cells

### DIFF
--- a/playground/preview.html
+++ b/playground/preview.html
@@ -6,12 +6,13 @@
   <title>djot preview</title>
   <style>
 html {
-    line-height: 1.3;
-    font-family: serif;
-    font-size: 20px;
-    height: 100%;
+  line-height: 1.3;
+  font-family: serif;
+  font-size: 20px;
+  height: 100%;
 }
-code { font-size: 16px;
+code {
+  font-size: 16px;
 }
 table, tr, td {
   border-collapse: collapse;

--- a/playground/preview.html
+++ b/playground/preview.html
@@ -17,7 +17,7 @@ code {
 table {
   border-collapse: collapse;
 }
-tr, td {
+th, td {
   border: 1px solid #ddd;
 }
   </style>

--- a/playground/preview.html
+++ b/playground/preview.html
@@ -19,6 +19,7 @@ table {
 }
 th, td {
   border: 1px solid #ddd;
+  padding: 0 0.3em;
 }
   </style>
   <script type="text/javascript" id="MathJax-script" async

--- a/playground/preview.html
+++ b/playground/preview.html
@@ -14,8 +14,10 @@ html {
 code {
   font-size: 16px;
 }
-table, tr, td {
+table {
   border-collapse: collapse;
+}
+tr, td {
   border: 1px solid #ddd;
 }
   </style>


### PR DESCRIPTION
_Originally submitted at https://github.com/jgm/djot/pull/177._

The stylesheet had a rule that was probably a typo, since it adds a border to the entire rows (`<tr>`), which is redundant with the border added to the cells (`<td>`); and it fails to add a border to `<th>` elements. So the following table:

```
| test | foo |
|------|-----|
| bar  | baz |
```

currently looks like this:

![image](https://user-images.githubusercontent.com/478237/209790996-a2693a75-142f-4213-a49d-c9fbc0829dd5.png)

With this change (in particular, 3f6ce3c), it will look like this:

![image](https://user-images.githubusercontent.com/478237/209791315-a490d3a9-7189-4be7-b0cc-1adcf4cc4245.png)

Note that I also added some cell padding (5927408).