### PR TITLE
enable isolatedModules flag for tsc

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -493,7 +493,7 @@ function isCaption(node : Row | Caption) : node is Caption {
 }
 
 
-export {
+export type {
   Attributes,
   SourceLoc,
   Pos,
@@ -558,6 +558,8 @@ export {
   Reference,
   Footnote,
   Visitor,
+}
+export {
   isInline,
   isBlock,
   isRow,

--- a/src/djot-renderer.ts
+++ b/src/djot-renderer.ts
@@ -670,7 +670,9 @@ const renderDjot = function(doc : Doc,
   return new DjotRenderer(doc, options).render();
 }
 
-export {
+export type {
   DjotRenderOptions,
+}
+export {
   renderDjot
 }

--- a/src/event.ts
+++ b/src/event.ts
@@ -5,4 +5,4 @@ interface Event {
 
 }
 
-export { Event }
+export type { Event }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -154,9 +154,11 @@ const applyFilter = function(node : Doc, filter : Filter) : void {
   }
 }
 
-export {
+export type {
   Action,
   FilterPart,
   Filter,
-  applyFilter
+}
+export {
+  applyFilter,
 }

--- a/src/html.ts
+++ b/src/html.ts
@@ -456,8 +456,10 @@ const renderHTML = function(ast: Doc, options: HTMLRenderOptions = {}): string {
   return renderer.render(ast);
 }
 
+export type {
+  HTMLRenderOptions
+}
 export {
   renderHTML,
-  HTMLRenderer,
-  HTMLRenderOptions
+  HTMLRenderer
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -28,8 +28,10 @@ interface Options {
   warn?: (warning : Warning) => void;
 }
 
+export type {
+  SourceLoc,
+  Options,
+}
 export {
   Warning,
-  SourceLoc,
-  Options
 }

--- a/src/pandoc.ts
+++ b/src/pandoc.ts
@@ -968,11 +968,14 @@ const fromPandoc = function(pandoc : Pandoc, options ?: Options) : Doc {
   return new PandocParser(options).fromPandoc(pandoc);
 }
 
-export { PandocRenderOptions,
-         Pandoc,
-         PandocElt,
-         PandocMeta,
-         PandocAttr,
-         toPandoc,
-         fromPandoc
+export type {
+  PandocRenderOptions,
+  Pandoc,
+  PandocElt,
+  PandocMeta,
+  PandocAttr,
+}
+export {
+  toPandoc,
+  fromPandoc
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1320,10 +1320,11 @@ const renderAST = function(doc: Doc): string {
 }
 
 
-
+export type {
+  ParseOptions,
+}
 export {
   parse,
-  ParseOptions,
   renderAST,
   getStringContent,
   isBlock,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "outDir": "lib",
     "declaration": true,
-    "declarationDir": "types"
+    "declarationDir": "types",
+    "isolatedModules": true
   },
   "include": [
     "src/attributes.ts",


### PR DESCRIPTION
The theory behind tsc is that it's a "null" compiler, in a sense that it just strips type annotations. As a corollary, purely syntax-based compiler which just erases type annotations should be correct.

Sadly, this property was eroded at some point, and this days the result of type-script compilation sometimes depends on the types. This breaks tools which try to process file-at-a-time.

The isolatedModules flag closes this loophole.

In my particular case, I am using djot from deno, and that does require this flag to be set.

The impact for djot is pretty minimal: we just need to flag some exports as type-only exports, so that it is clear without context that they compile down to nothing. 