### PR TITLE
Update readme on event parser function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ and `pos` (`{ line: number, col: number, offset: number }` if defined).
 
 ### Parsing djot to a stream of events
 
-`new EventParser(input : string, options : Options = {})`
+`parseEvents(input : string, options : Options = {})`
 
 Exposes an iterator over events, each with the form
 `{startpos : number, endpos : number, annot : string}`.
 Example of usage:
 
 ```js
-for (let event in new djot.EventParser("Hi _there_")) {
+for (let event of parseEvents("Hi _there_")) {
   console.log(event)
 }
 ```


### PR DESCRIPTION
Exposed event parser function has changed from EventParser to parseEvents at 393bde2bff11631980e9fbcda52804f3f3e4b857.