### PR TITLE
Simplify AST for TaskListItem

### DIFF
--- a/djot-schema.json
+++ b/djot-schema.json
@@ -382,13 +382,6 @@
             ],
             "type": "object"
         },
-        "CheckboxStatus": {
-            "enum": [
-                "checked",
-                "unchecked"
-            ],
-            "type": "string"
-        },
         "CodeBlock": {
             "additionalProperties": false,
             "properties": {
@@ -3301,8 +3294,8 @@
                 "attributes": {
                     "$ref": "#/definitions/Attributes"
                 },
-                "checkbox": {
-                    "$ref": "#/definitions/CheckboxStatus"
+                "checked": {
+                    "type": "boolean"
                 },
                 "children": {
                     "items": {
@@ -3743,4 +3736,3 @@
     ],
     "type": "object"
 }
-

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -106,11 +106,9 @@ interface TaskList extends HasAttributes {
 
 interface TaskListItem extends HasAttributes {
   tag: "task_list_item";
-  checkbox: CheckboxStatus;
+  checked: boolean;
   children: Block[];
 }
-
-type CheckboxStatus = "checked" | "unchecked";
 
 interface OrderedList extends HasAttributes {
   tag: "ordered_list";
@@ -377,7 +375,7 @@ type AstNode =
   | Cell
   | Caption
   | Footnote
-  | Reference 
+  | Reference
   ;
 
 type Visitor<C, R> = {
@@ -520,7 +518,6 @@ export type {
   ListItem,
   TaskList,
   TaskListItem,
-  CheckboxStatus,
   DefinitionList,
   DefinitionListItem,
   Term,

--- a/src/djot-renderer.ts
+++ b/src/djot-renderer.ts
@@ -442,7 +442,7 @@ class DjotRenderer {
           }
         }
         this.needsBlankLine = false;
-        this.lit(`- [${item.checkbox === "checked" ? "X" : " "}]`);
+        this.lit(`- [${item.checked  ? "X" : " "}]`);
         this.space();
         this.prefixes.push(" ".repeat(2));
         this.renderChildren<Block>(item.children);

--- a/src/html.ts
+++ b/src/html.ts
@@ -206,7 +206,7 @@ class HTMLRenderer {
 
       case "task_list_item":
         return this.inTags("li", node, 2,
-                           { class: node.checkbox === "checked"
+                           { class: node.checked
                                ? "checked" : "unchecked" });
 
       case "definition_list_item":

--- a/src/pandoc.ts
+++ b/src/pandoc.ts
@@ -1,7 +1,7 @@
 import { AstNode, Doc, Block, Caption, Row, Cell, Alignment,
          TaskListItem, OrderedListStyle, ListItem, Inline, Reference,
          Span, Verbatim, Image, Link,
-         Attributes, CodeBlock, Heading, Div, Table, CheckboxStatus,
+         Attributes, CodeBlock, Heading, Div, Table,
          DefinitionListItem, Footnote } from "./ast";
 import { Options, Warning } from "./options";
 
@@ -124,8 +124,8 @@ class PandocRenderer {
       const self = this;
     return function(item : AstNode) : PandocElt[] {
       let elts = self.toPandocChildren(item);
-      if ("checkbox" in item && item.checkbox && elts[0].t === "Para") {
-        if (item.checkbox === "checked") {
+      if ("checked" in item && elts[0].t === "Para") {
+        if (item.checked) {
           elts[0].c.unshift({t: "Str", c: "☒"}, {t: "Space"});
         } else {
           elts[0].c.unshift({t: "Str", c: "☐"}, {t: "Space"});
@@ -479,7 +479,7 @@ const isPlainOrPara = function(x : PandocElt) : boolean {
   return (x.t === "Plain" || x.t === "Para");
 }
 
-const hasCheckbox = function(elt : PandocElt[]) : CheckboxStatus | null {
+const hasCheckbox = function(elt : PandocElt[]) : boolean | null {
   if (!elt[0]) {
     return null;
   }
@@ -491,11 +491,11 @@ const hasCheckbox = function(elt : PandocElt[]) : CheckboxStatus | null {
     if (x.c[0].c === "☒") {
       x.c.shift(); // remove the checkbox
       x.c.shift();
-      return "checked";
+      return true;
     } else if (x.c[0].c === "☐") {
       x.c.shift(); // remove the checkbox
       x.c.shift();
-      return "unchecked";
+      return false;
     } else {
       return null;
     }
@@ -788,7 +788,7 @@ class PandocParser {
           rawitems = block.c[1];
         }
         for (let i=0; i<rawitems.length; i++) {
-          const checkbox = hasCheckbox(rawitems[i]);
+          const checked = hasCheckbox(rawitems[i]);
           const children = rawitems[i].map((b : PandocElt) => {
                                    if (b.t === "Plain") {
                                      tight = true;
@@ -797,9 +797,9 @@ class PandocParser {
                                    }
                                    return this.fromPandocBlock(b);
                                 });
-          if (checkbox !== null) {
+          if (checked !== null) {
             taskListItems.push( { tag: "task_list_item",
-                                  checkbox: checkbox,
+                                  checked: checked,
                                   children: children });
           } else {
             items.push( { tag: "list_item",

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -870,12 +870,12 @@ const parse = function(input: string, options: ParseOptions = {}): Doc {
               attributes: node.attributes,
               pos: node.pos});
           }
-        } else if (node.data.checkbox) {
+        } else if ("checked" in node.data) {
           addChildToTip({
             tag: "task_list_item",
             children: node.children,
             attributes: node.attributes,
-            checkbox: node.data.checkbox,
+            checked: node.data.checked,
             pos: node.pos});
         } else {
           addChildToTip({
@@ -887,11 +887,11 @@ const parse = function(input: string, options: ParseOptions = {}): Doc {
       },
 
       checkbox_checked: (suffixes, startpos, endpos, pos) => {
-        topContainer().data.checkbox = "checked";
+        topContainer().data.checked = true;
       },
 
       checkbox_unchecked: (suffixes, startpos, endpos, pos) => {
-        topContainer().data.checkbox = "unchecked";
+        topContainer().data.checked = false;
       },
 
       ["+block_quote"]: (suffixes, startpos, endpos, pos) => {


### PR DESCRIPTION
Syntactically, we allow only two status here, checked and unchecked, so a boolean should be enough.

cc #55