### PR TITLE
Allow comment end with attribute end.

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -84,8 +84,11 @@ handlers[State.SCANNING] = function(parser : AttributeParser, pos : number) {
 }
 
 handlers[State.SCANNING_COMMENT] = function(parser : AttributeParser, pos : number) {
-  if (parser.subject.charAt(pos) === '%') {
+  const c = parser.subject.charAt(pos)
+  if (c === '%') {
     return State.SCANNING;
+  } else if (c == '}') {
+    return State.DONE;
   } else {
     return State.SCANNING_COMMENT;
   }

--- a/test/attributes.test
+++ b/test/attributes.test
@@ -209,7 +209,8 @@ two
 ```
 
 Comments start at a `%` character
-(not in quotes) and end with another `%`.
+(not in quotes) and end with another `%` or
+the end of the attribute (`}`).
 These can be used to comment up an attribute
 list or without any real attributes.
 
@@ -217,6 +218,12 @@ list or without any real attributes.
 foo{#ident % this is a comment % .class}
 .
 <p><span id="ident" class="class">foo</span></p>
+```
+
+```
+foo{#ident % this is a comment}
+.
+<p><span id="ident">foo</span></p>
 ```
 
 In block-level comment, subsequent lines must


### PR DESCRIPTION
This pull request allows a comment in an attribute end with an attribute end, as stated in the [Djot syntax reference > Inline attributes][man].

> `%` begins a comment, which ends with the next `%` or the end of the attribute (`}`).

[man]: https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html#inline-attributes
