### PR TITLE
Fix filters to not run twice

### DIFF
--- a/src/filter.spec.ts
+++ b/src/filter.spec.ts
@@ -81,6 +81,19 @@ const fancyFilter : Filter = () => {
         };
 };
 
+const countSpanRuns : Filter = () => {
+  let count = 0;
+  return {
+    span: (e) => {
+      ++count;
+      return {
+        tag: "span",
+        children: [{tag: "str", text: String(count)}]
+      };
+    }
+  }
+};
+
 describe("applyFilter", () => {
   it("capitalizes text", () => {
     const ast = parse("Hello *there* `code`");
@@ -182,6 +195,16 @@ footnotes
 `);
   });
 
+  it("doesn't run exit filters twice", () => {
+    const ast = parse("[count goes here]{.span}");
+    applyFilter(ast, countSpanRuns);
+    expect(renderAST(ast)).toEqual(
+`doc
+  para
+    span
+      str text="1"
+`);
+  });
 
   it("doesn't loop", () => {
     const ast = parse("Hello _there_ friend");

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -150,7 +150,6 @@ class Walker {
     while (!this.finished) {
       callback(this); // apply the action to current this state
       const topStack = this.stack && this.stack[this.stack.length - 1];
-      this.enter = this.enter && "children" in this.current;
       if (this.enter) {
         if ("children" in this.current &&
             this.current.children.length > 0) {
@@ -193,24 +192,20 @@ const applyFilterPartToNode = function(node : AstNode, enter : boolean,
   if (!trans) {
     return false;
   }
-  if (enter && "enter" in trans) {
-    const transform = trans.enter;
-    if (!transform) {
-      return false;
+  let transform;
+  if (enter) {
+    if ("enter" in trans && trans.enter) {
+      transform = trans.enter;
     }
-    return transform(node);
   } else {
-    let transform;
     if ("exit" in trans && trans.exit) {
       transform = trans.exit;
-    } else if ("enter" in trans && trans.enter) {
-      transform = trans.enter;
     } else {
       transform = trans;
     }
-    if (typeof transform === "function") {
-      return transform(node);
-    }
+  }
+  if (typeof transform === "function") {
+    return transform(node);
   }
 }
 


### PR DESCRIPTION
There are two related changes here:

1. In the `Walker` code, `this.enter` gets set to false unnecessarily early if the node has no children. This causes it to skip the `if` branch which would otherwise cause the filter to run a second time for `exit`, and move straight to advancing to the parent node.

2. In `applyFilterPartToNode`, the `exit` filter will be run if `enter == false` OR if `!("enter" in trans)`. But it should only run in the first case, NOT the second. This commit refactors the code to prevent the `exit` filter from running twice in the case that no `enter` filter is defined.

   A test has been added to check for this.