### PR TITLE
attributes: allow non-ascii id

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -105,7 +105,7 @@ handlers[State.SCANNING_COMMENT] = function(parser : AttributeParser, pos : numb
 handlers[State.SCANNING_ID] = function(parser : AttributeParser, pos : number) {
   const c = parser.subject.charAt(pos);
 
-  if ((/^\w/.exec(c) !== null) || c === '_' || c === '-' || c === ':') {
+  if ((/^[^\]\[~!@#$%^&*(){}`,.<>\\|=+/?\s]/.exec(c) !== null)) {
     return State.SCANNING_ID;
   } else if (c === '}') {
     if (parser.begin && parser.lastpos && parser.lastpos > parser.begin) {


### PR DESCRIPTION
Current djot.js allows non-ascii heading:

    # 中文

After `renderDjot` it becomes:

    {#中文}
    # 中文

As djot.js use `\w` to scan id,
it fails to parse `{#中文}` as block attributes.

I copy the regexp from `getUniqueIdentifier` to fix this issue.

Signed-off-by: black-desk <me@black-desk.cn>
