### PR TITLE
Add prepare and pretest scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   ],
   "types": "./types/index.d.ts",
   "scripts": {
-    "test": "npx jest",
-    "build": "npx tsc && npx webpack",
-    "bench": "npx webpack && node ./bench/bench.js"
+    "build": "tsc && webpack",
+    "prepare": "npm run build",
+    "pretest": "npm run build",
+    "test": "jest",
+    "bench": "npm run build && node ./bench/bench.js"
   },
   "files": [
     "./dist/djot.js",


### PR DESCRIPTION
For use @djot/djot.js through git,
we need a "prepare" scripts to run tsc and webpack.

https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts

> prepare (since npm@4.0.0)
> - NOTE:
>   If a package being installed through git contains a prepare script,
>   its dependencies and devDependencies will be installed,
>   and the prepare script will be run,
>   before the package is packaged and installed.

Signed-off-by: black-desk <me@black-desk.cn>
