### PR TITLE
Move package.json `exports`' `default` condition to last position

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "exports": {
     ".": {
       "require": "./dist/djot.js",
-      "default": "./lib/index.js",
-      "types": "./types/index.d.ts"
+      "types": "./types/index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "bin": {


### PR DESCRIPTION
According to the [Node.js' documentation](https://nodejs.org/api/packages.html#conditional-exports:~:text=This%20condition%20should%20always%20come%20last.), `default` condition of `exports` field of package.json must be last.

This bug breaks djot.js on Next.js ([reproduction](https://github.com/AumyF/repro-djot-exports-field-order)).