### PR TITLE
test: fix and test number comments

### DIFF
--- a/src/block.spec.ts
+++ b/src/block.spec.ts
@@ -23,7 +23,7 @@ describe("EventParser", () => {
   it("parses block quotes", () => {
     const events = [];
     for (const event of parseEvents("> hello\n> there\nlazy\n>\n> hi\n")) {
-      //                            01234567 89012345 67890 12 345678
+      //                             01234567 89012345 67890 12 34567
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -46,7 +46,7 @@ describe("EventParser", () => {
   it("parses headings", () => {
     const events = [];
     for (const event of parseEvents("## hello\n## there\nlazy\n")) {
-      //                            012345678 901234567 89012
+      //                             012345678 901234567 89012
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -63,7 +63,7 @@ describe("EventParser", () => {
   it("parses reference definitions", () => {
     const events = [];
     for (const event of parseEvents("[foo]: bar\n baz\n")) {
-      //                            0123456789 01234 5
+      //                             01234567890 12345
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -78,7 +78,7 @@ describe("EventParser", () => {
   it("parses tables", () => {
     const events = [];
     for (const event of parseEvents("| a | b |\n|--|--:|\n|33|2| ")) {
-      //                            012345678 901234567 8901234
+      //                             0123456789 012345678 9012345
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -111,7 +111,7 @@ describe("EventParser", () => {
   it("parses code blocks", () => {
     const events = [];
     for (const event of parseEvents("```` python\nif x == 3:\n  y = 4\n````\n")) {
-      //                            01234567890 12345678901 23456789 01234 5
+      //                             012345678901 23456789012 34567890 12345
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -126,7 +126,7 @@ describe("EventParser", () => {
   it("parses list items", () => {
     const events = [];
     for (const event of parseEvents("- one\n- two\n1. three\n(iv) four\n\n - sub\n\n   two\n")) {
-      //                             012345 678901 234567890 1234567890 1 2345678 9  123456
+      //                             012345 678901 234567890 1234567890 1 2345678 9 0123456
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -173,7 +173,7 @@ describe("EventParser", () => {
   it("parses captions", () => {
     const events = [];
     for (const event of parseEvents(" ^ This is a\n*capt*\n\n")) {
-      //                            012345678901 2345678 9 0
+      //                             0123456789012 3456789 0
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -191,7 +191,7 @@ describe("EventParser", () => {
   it("parses thematic breaks", () => {
     const events = [];
     for (const event of parseEvents(" - - - -\n")) {
-      //                            012345678901 2345678 9 0
+      //                             012345678
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -202,7 +202,7 @@ describe("EventParser", () => {
   it("parses fenced divs", () => {
     const events = [];
     for (const event of parseEvents(":::: foo \nhello\n\nhi\n::::")) {
-      //                            012345678 901234 5 6789 01234 56789
+      //                             0123456789 012345 6 789 0123
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -224,7 +224,7 @@ describe("EventParser", () => {
     const events = [];
     for (const event of parseEvents(
           "[^note]: This is a\nnote\n\n  second par\n\nafter note\n")) {
-      //   012345678901234567 89012 3 4567890123456 7 89012345678 9
+      //   0123456789012345678 90123 4 5678901234567 8 90123456789
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -251,7 +251,7 @@ describe("EventParser", () => {
     const events = [];
     for (const event of parseEvents(
           "{.foo}\n{#bar\n .baz}\nHello")) {
-      //   012345 678901 2345678 901234
+      //   0123456 789012 3456789 01234
       events.push(event);
     }
     expect(events).toStrictEqual([
@@ -274,7 +274,7 @@ describe("EventParser", () => {
   it("parses failed block attributes as para", () => {
     const events = [];
     for (const event of parseEvents("{.foo\nbar *baz*\n\n")) {
-      //   012345 678901234 5 6
+      //                             012345 6789012345 6
       events.push(event);
     }
     expect(events).toStrictEqual([

--- a/src/inline.spec.ts
+++ b/src/inline.spec.ts
@@ -13,7 +13,7 @@ describe("InlineParser", () => {
 
   it("parses verbatim", () => {
     const parser = new InlineParser("x ``` hello ``there ``` x");
-    //                             0123456789012345678901234
+    //                               0123456789012345678901234
     parser.feed(0,24);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "str", startpos: 0, endpos: 1 },
@@ -45,7 +45,7 @@ describe("InlineParser", () => {
 
   it("parses autolinks", () => {
     const parser = new InlineParser('<http://example.com?foo=bar&baz=&amp;x2>');
-    //                             0123456789012345678901234567890123456789
+    //                               0123456789012345678901234567890123456789
     parser.feed(0,39);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "+url", startpos: 0, endpos: 0 },
@@ -56,7 +56,7 @@ describe("InlineParser", () => {
 
   it("parses email autolinks", () => {
     const parser = new InlineParser('<me@example.com>');
-    //                             0123456789012345
+    //                               0123456789012345
     parser.feed(0,15);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "+email", startpos: 0, endpos: 0 },
@@ -67,7 +67,7 @@ describe("InlineParser", () => {
 
   it("parses super/subscript", () => {
     const parser = new InlineParser('H~2~O e=mc^2^ test{^two words^}');
-    //                             0123456789012345678901234567890
+    //                               0123456789012345678901234567890
     parser.feed(0,30);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "str", startpos: 0, endpos: 0 },
@@ -90,7 +90,7 @@ describe("InlineParser", () => {
 
   it("parses emphasis", () => {
     const parser = new InlineParser('_hello *there*_ world');
-    //                             012345678901234567890
+    //                               012345678901234567890
     parser.feed(0,20);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "+emph", startpos: 0, endpos: 0 },
@@ -105,7 +105,7 @@ describe("InlineParser", () => {
 
   it("parses mark", () => {
     const parser = new InlineParser('{=hello=}');
-    //                             012345678
+    //                               012345678
     parser.feed(0,8);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "open_marker", startpos: 0, endpos: 0 },
@@ -117,7 +117,7 @@ describe("InlineParser", () => {
 
   it("parses inserted", () => {
     const parser = new InlineParser('{+hello+}');
-    //                             012345678
+    //                               012345678
     parser.feed(0,8);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "open_marker", startpos: 0, endpos: 0 },
@@ -129,7 +129,7 @@ describe("InlineParser", () => {
 
   it("parses quoted", () => {
     const parser = new InlineParser('"dog\'s breakfast"');
-    //                             0123 4567890123456
+    //                               01234 567890123456
     parser.feed(0,16);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "+double_quoted", startpos: 0, endpos: 0 },
@@ -187,7 +187,7 @@ describe("InlineParser", () => {
 
   it("parses inline links", () => {
     const parser = new InlineParser('[foobar](url)');
-    //                             0123456789012
+    //                               0123456789012
     parser.feed(0,12);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "+linktext", startpos: 0, endpos: 0 },
@@ -201,7 +201,7 @@ describe("InlineParser", () => {
 
   it("parses reference links", () => {
     const parser = new InlineParser('[foobar][1]');
-    //                             01234567890
+    //                               01234567890
     parser.feed(0,10);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "+linktext", startpos: 0, endpos: 0 },
@@ -215,7 +215,7 @@ describe("InlineParser", () => {
 
   it("parses inline images", () => {
     const parser = new InlineParser('![foobar](url)');
-    //                             01234567890123
+    //                               01234567890123
     parser.feed(0,13);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "image_marker", startpos: 0, endpos: 0 },
@@ -230,7 +230,7 @@ describe("InlineParser", () => {
 
   it("parses symbs", () => {
     const parser = new InlineParser(':+1:');
-    //                             0123
+    //                               0123
     parser.feed(0,3);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "symb", startpos: 0, endpos: 3 }
@@ -239,7 +239,7 @@ describe("InlineParser", () => {
 
   it("parses ellipses", () => {
     const parser = new InlineParser('...');
-    //                             0123
+    //                               012
     parser.feed(0,2);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "ellipses", startpos: 0, endpos: 2 }
@@ -248,7 +248,7 @@ describe("InlineParser", () => {
 
   it("parses dashes", () => {
     const parser = new InlineParser('a---b--c');
-    //                             01234567
+    //                               01234567
     parser.feed(0,7);
     expect(parser.getMatches()).toStrictEqual([
       { annot: "str", startpos: 0, endpos: 0 },

--- a/src/meta.spec.ts
+++ b/src/meta.spec.ts
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const override = "OVERRIDE" in process.env;
+
+/// In `inline.spec.ts` and `block.spec.ts` we have code like:
+///
+/// ```
+/// const parser = new InlineParser('{=hello=}');
+/// //                               012345678
+/// ```
+///
+/// This function checks that the comments are aligned with the strings they are annotating.
+function checkNumberComments(filename: string) {
+  const lines = fs.readFileSync(path.resolve(__dirname, filename), "utf-8").split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const match = /^( +)\/\/  +(\d[\d ]*\d)( *)$/.exec(lines[i]);
+    if (match) {
+      const prevLine = lines[i - 1];
+      const quoteIdx = prevLine.search(/'|"/);
+      const expectedStartIdx = quoteIdx + 1;
+
+      let annotation = "";
+      let num = 0;
+      for (let j = quoteIdx + 1; j < prevLine.lastIndexOf(prevLine[quoteIdx]); j++) {
+        if (prevLine[j - 1] == "\\") annotation += " ";
+        else {
+          annotation += num;
+          num = (num + 1) % 10;
+        }
+      }
+      const expectedComment = match[1] + "//" + " ".repeat(expectedStartIdx - match[1].length - "//".length) + annotation.trimEnd();
+
+      if (override) {
+        lines[i] = expectedComment;
+      } else if (lines[i] != expectedComment) {
+        throw new Error(
+          `unexpected comment at line ${i + 1}\n` +
+            `expected: ${expectedComment}\n` +
+            `received: ${lines[i]}\n`,
+        );
+      }
+    }
+  }
+  if (override)
+    fs.writeFileSync(path.resolve(__dirname, filename), lines.join("\n"));
+}
+
+it("number comments in inline.spec.ts are aligned", () => {
+  checkNumberComments("inline.spec.ts");
+});
+
+it("number comments in block.spec.ts are aligned", () => {
+  checkNumberComments("block.spec.ts");
+});


### PR DESCRIPTION
Many comments were misaligned in 9f7ddab (eslint fixes) by changing `let` to `const` which is two chars longer.

This commit fixes the alignments as well as consistently puts the digits for `\n` below the blackslash.
A respective test is introduced (which can update all comments if the OVERRIDE environment variable is set).