### PR TITLE
Export Event type

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -1119,4 +1119,4 @@ const parseEvents = function(input : string, options : Options = {}) {
   return new EventParser(input, options);
 }
 
-export { parseEvents }
+export { parseEvents, type Event }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { parse, renderAST } from "./parse";
-export { parseEvents } from "./block";
+export { parseEvents, type Event } from "./block";
 export { renderHTML, HTMLRenderer } from "./html";
 export { applyFilter } from "./filter";
 export { fromPandoc, toPandoc } from "./pandoc";


### PR DESCRIPTION
This enables users to refer to the EventParser as `Iterable<Event>` which is much more readable than `ReturnType<typeof parseEvents>`.