### PR TITLE
`parse.ts` now exports `parseFromEvents` [API change].

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -124,7 +124,9 @@ const normalizeLabel = function(label : string): string {
   return label.trim().replace(/[ \t\r\n]+/g, " ")
 }
 
-const parse = function(input: string, options: ParseOptions = {}): Doc {
+const parseFromEvents = function(events: Event[],
+                                 input: string,
+                                 options: ParseOptions = {}): Doc {
 
   const linestarts: number[] = [-1];
 
@@ -172,7 +174,6 @@ const parse = function(input: string, options: ParseOptions = {}): Doc {
   const identifiers: Record<string, boolean> = {}; // identifiers used
   const blockAttributes: Attributes = {}; // accumulated block attributes
   let listDepth = 0;
-  const parser = parseEvents(input, options);
   const warn = options.warn || (() => {});
   const addBlockAttributes = function(container: HasAttributes) {
     if (Object.keys(blockAttributes).length > 0) {
@@ -1248,7 +1249,7 @@ const parse = function(input: string, options: ParseOptions = {}): Doc {
     }];
 
   let lastpos = 0;
-  for (const event of parser) {
+  for (const event of events) {
     handleEvent(containers, event);
     lastpos = event.endpos;
   }
@@ -1358,11 +1359,16 @@ const renderAST = function(doc: Doc): string {
   return buff.join("");
 }
 
+const parse = function(input: string, options: ParseOptions = {}): Doc {
+  const parser = parseEvents(input, options);
+  return parseFromEvents(Array.from(parser), input, options);
+}
 
 export type {
   ParseOptions,
 }
 export {
+  parseFromEvents,
   parse,
   renderAST,
   getStringContent,


### PR DESCRIPTION
This takes an `Event[]` parameter, which can be produced from an `EventParser` using `Array.from()`.

`parse` is now defined in terms of `parseFromEvents`.

This will help users who need both the parsed content and the event stream. Previously they had to do the parsing twice, once using `parseEvents` and once with `parse` (which itself calls `parseEvents`). This can now be avoided; `parseEvents` can be called once and then `parseFromEvents` can be called using the extracted events.

Users of the old `parse` function should not see any changes.

Note: it is possible that there could be performance effects due to the reification of the Event array, since the previous version of `parse` consumed Events as they were streamedfrom `parseEvents` rather than taking an array of all the Events as parameter. However, in our own benchmarks we don't see any significant differences.

Closes #111.