### PR TITLE
Add caption support for images and block quotes

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -40,6 +40,7 @@ type Block =
   | TaskList
   | DefinitionList
   | Table
+  | Figure
   ;
 
 interface Para extends HasAttributes {
@@ -130,6 +131,16 @@ type OrderedListStyle =
 
 interface Caption extends HasAttributes {
   tag: "caption";
+  children: Inline[];
+}
+
+interface Figure extends HasAttributes {
+  tag: "figure";
+  children: AstNode[];
+}
+
+interface Figcaption extends HasAttributes {
+  tag: "figcaption";
   children: Inline[];
 }
 
@@ -378,8 +389,10 @@ type AstNode =
   | Row
   | Cell
   | Caption
+  | Figure
+  | Figcaption
   | Footnote
-  | Reference 
+  | Reference
   ;
 
 type Visitor<C, R> = {
@@ -430,6 +443,8 @@ type Visitor<C, R> = {
   row?: (node: Row, context: C) => R;
   cell?: (node: Cell, context: C) => R;
   caption?: (node: Caption, context: C) => R;
+  figure?: (node: Figure, context: C) => R;
+  figcaption?: (node: Figcaption, context: C) => R;
   footnote?: (node: Footnote, context: C) => R;
   reference?: (node: Reference, context: C) => R;
 };
@@ -450,6 +465,7 @@ const blockTags : Record<string, boolean> = {
   task_list: true,
   definition_list: true,
   table: true,
+  figure: true,
   reference: true,
   footnote: true
 };
@@ -529,6 +545,8 @@ export type {
   Definition,
   Table,
   Caption,
+  Figure,
+  Figcaption,
   Row,
   Cell,
   Alignment,

--- a/src/html.ts
+++ b/src/html.ts
@@ -274,6 +274,12 @@ class HTMLRenderer {
         return result;
       }
 
+      case "figure":
+        return this.inTags("figure", node, 2);
+
+      case "figcaption":
+        return this.inTags("figcaption", node, 1);
+
       case "table":
         return this.inTags("table", node, 2);
 

--- a/test/tables.test
+++ b/test/tables.test
@@ -123,3 +123,51 @@ determines the alignment for following cells, until the next header.
 </tr>
 </table>
 ```
+
+Image caption:
+
+```
+![Alt text](url.jpg)
+
+^ Image caption
+.
+<figure>
+<img alt="Alt text" src="url.jpg"><figcaption>Image caption</figcaption>
+</figure>
+```
+
+Image caption with formatting:
+
+```
+![Photo](photo.png)
+
+^ A _beautiful_ photo
+.
+<figure>
+<img alt="Photo" src="photo.png"><figcaption>A <em>beautiful</em> photo</figcaption>
+</figure>
+```
+
+Block quote caption:
+
+```
+> To be or not to be.
+^ William Shakespeare
+.
+<figure>
+<blockquote>
+<p>To be or not to be.</p>
+</blockquote>
+<figcaption>William Shakespeare</figcaption>
+</figure>
+```
+
+Caption after non-captionable element is ignored:
+
+```
+A paragraph.
+^ Not a caption
+.
+<p>A paragraph.
+^ Not a caption</p>
+```


### PR DESCRIPTION
## Summary

- Extends the existing table caption syntax (`^ caption text`) to also work with images and block quotes
- Images with captions are wrapped in `<figure>` / `<figcaption>` HTML elements
- Block quotes with captions are similarly wrapped in `<figure>` / `<figcaption>`
- Adds `Figure` and `Figcaption` AST node types with full visitor support
- Caption after a non-captionable element (plain paragraph) is left as paragraph content

### Examples

Image caption:
```djot
![Alt text](url.jpg)

^ Image caption
```
→ `<figure><img alt="Alt text" src="url.jpg"><figcaption>Image caption</figcaption></figure>`

Block quote caption:
```djot
> To be or not to be.
^ William Shakespeare
```
→ `<figure><blockquote><p>To be or not to be.</p></blockquote><figcaption>William Shakespeare</figcaption></figure>`

Companion spec PR: jgm/djot#373

A reference implementation exists in [djot-php](https://github.com/php-collective/djot-php/blob/master/docs/enhancements.md#captions-for-images-tables-and-block-quotes).