### PR TITLE
Add test cases for under-tested spec behaviors

### DIFF
--- a/test/attributes.test
+++ b/test/attributes.test
@@ -247,6 +247,16 @@ Paragraph.
 <p>Paragraph.</p>
 ```
 
+An attribute specifier containing only a comment is stripped
+from the output:
+
+```
+Foo bar {% This is a comment, spanning
+multiple lines %} baz.
+.
+<p>Foo bar  baz.</p>
+```
+
 Inline attributes can be empty:
 
 ```

--- a/test/links_and_images.test
+++ b/test/links_and_images.test
@@ -166,6 +166,14 @@ Attributes on the link override those on references:
 <p><a href="url"><img alt="image" src="img.jpg"></a></p>
 ```
 
+Inline attributes on images go on the <img> tag:
+
+```
+![alt](img.jpg){.photo}
+.
+<p><img alt="alt" src="img.jpg" class="photo"></p>
+```
+
 ```
 [unclosed](hello *a
 b*

--- a/test/lists.test
+++ b/test/lists.test
@@ -77,6 +77,35 @@ a list
 </ul>
 ```
 
+In a loose list, all items get <p> wrapping, including items
+that appear before the blank line that makes the list loose:
+
+```
+- a
+- b
+- c
+
+  more
+
+- d
+.
+<ul>
+<li>
+<p>a</p>
+</li>
+<li>
+<p>b</p>
+</li>
+<li>
+<p>c</p>
+<p>more</p>
+</li>
+<li>
+<p>d</p>
+</li>
+</ul>
+```
+
 ```
 - one
 lazy


### PR DESCRIPTION
- Inline comment-only attributes stripped from output (spec example)
- Inline attributes on images applied to the `<img>` tag
- Loose lists wrap all items in `<p>`, including those before the blank line that triggers looseness

Discovered in the same way as https://github.com/jgm/djot.js/pull/130.