### PR TITLE
add file inclusion without AST nodes; fixes #85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@djot/djot",
-  "version": "0.2.4",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@djot/djot",
-      "version": "0.2.4",
+      "version": "0.3.2",
       "license": "MIT",
       "bin": {
         "djot": "lib/cli.js"

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -379,7 +379,7 @@ type AstNode =
   | Cell
   | Caption
   | Footnote
-  | Reference 
+  | Reference
   ;
 
 type Visitor<C, R> = {
@@ -451,7 +451,7 @@ const blockTags : Record<string, boolean> = {
   definition_list: true,
   table: true,
   reference: true,
-  footnote: true
+  footnote: true,
 };
 
 function isBlock(node : AstNode) : node is Block {

--- a/src/block.ts
+++ b/src/block.ts
@@ -123,6 +123,8 @@ class EventParser {
   returned: number;
   specs: BlockSpec[];
   paraSpec: BlockSpec;
+  hasUnmatchedOpeners: boolean;
+  hasUnmatchedClosers: boolean;
 
   constructor(subject: string, options: Options = {}) {
     // Ensure the subject ends with a newline character
@@ -143,6 +145,8 @@ class EventParser {
     this.lastMatchedContainer = 0;
     this.finishedLine = false;
     this.returned = 0;
+    this.hasUnmatchedOpeners = false;
+    this.hasUnmatchedClosers = false;
     this.paraSpec =
     {
       name: "para",
@@ -773,6 +777,18 @@ class EventParser {
           this.matches.push(match);
         }
         last = match;
+      }
+      // Check for unmatched openers left in the inline parser
+      if (!this.hasUnmatchedOpeners) {
+        for (const k in ilparser.openers) {
+          if (ilparser.openers[k].length > 0) {
+            this.hasUnmatchedOpeners = true;
+            break;
+          }
+        }
+      }
+      if (!this.hasUnmatchedClosers && ilparser.hasUnmatchedClosers) {
+        this.hasUnmatchedClosers = true;
       }
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 import fs from "fs";
+import path from "path";
 import { performance } from "perf_hooks";
 import { parseEvents } from "./block";
-import { parse, renderAST } from "./parse";
+import { parse, renderAST, parseFromEvents } from "./parse";
 import { Doc } from "./ast";
 import { renderHTML } from "./html";
 import { applyFilter } from "./filter";
@@ -11,6 +12,7 @@ import { fromPandoc, toPandoc } from "./pandoc";
 import { renderDjot } from "./djot-renderer";
 import { version } from "./version";
 import { Warning } from "./options";
+import { preprocessInclusions, mergeInclusionEvents } from "./include";
 
 const warn = function(warning: Warning) : void {
   process.stderr.write(warning.render() + "\n");
@@ -150,10 +152,27 @@ for (const file of files) {
   }
 }
 
+const basePath = files[0] !== "/dev/stdin"
+  ? path.dirname(path.resolve(files[0]))
+  : process.cwd();
+
+const ppResult = preprocessInclusions(input, {
+  readFile: (p) => {
+    try { return fs.readFileSync(p, "utf8"); }
+    catch { return null; }
+  },
+  basePath,
+  warn,
+});
+input = ppResult.text;
+const inclusionRecords = ppResult.inclusions;
+
 try {
   if (to === "events") {
+    const rawEvents = Array.from(parseEvents(input, {warn: warn}));
+    const mergedEvents = mergeInclusionEvents(rawEvents, inclusionRecords);
     let start = true;
-    for (const event of parseEvents(input, {warn: warn})) {
+    for (const event of mergedEvents) {
       if (start) {
         process.stdout.write("[");
         start = false;
@@ -167,7 +186,9 @@ try {
     let startTime = performance.now();
     let ast : Doc | null = null;
     if (from === "djot") {
-      ast = parse(input, options);
+      const rawEvents = Array.from(parseEvents(input, options));
+      const mergedEvents = mergeInclusionEvents(rawEvents, inclusionRecords);
+      ast = parseFromEvents(mergedEvents, input, options);
     } else if (from === "pandoc") {
       ast = fromPandoc(JSON.parse(input));
     } else if (from === "ast") {

--- a/src/include.spec.ts
+++ b/src/include.spec.ts
@@ -1,0 +1,1058 @@
+import {
+  preprocessInclusions,
+  mergeInclusionEvents,
+  isImageFile,
+  isBinaryContent,
+  splitByCodeFences,
+  collectFootnoteLabels,
+  collectReferenceLabels,
+  collectExplicitIds,
+  renameFootnoteInText,
+  removeReferenceDefinition,
+  renameIdInText,
+  buildEventStreams,
+} from "./include";
+import { parseEvents } from "./block";
+import { parse, parseFromEvents } from "./parse";
+import { renderHTML } from "./html";
+import { Warning } from "./options";
+
+function mockReadFile(files: Record<string, string>): (p: string) => string | null {
+  return (p: string) => {
+    for (const [key, val] of Object.entries(files)) {
+      if (p.endsWith(key) || p === key) return val;
+    }
+    return null;
+  };
+}
+
+const noWarn = () => {};
+
+describe("isImageFile", () => {
+  it("returns true for common image extensions", () => {
+    expect(isImageFile("photo.png")).toBe(true);
+    expect(isImageFile("photo.jpg")).toBe(true);
+    expect(isImageFile("photo.jpeg")).toBe(true);
+    expect(isImageFile("photo.gif")).toBe(true);
+    expect(isImageFile("photo.svg")).toBe(true);
+    expect(isImageFile("photo.webp")).toBe(true);
+    expect(isImageFile("photo.bmp")).toBe(true);
+    expect(isImageFile("photo.avif")).toBe(true);
+    expect(isImageFile("photo.ico")).toBe(true);
+  });
+
+  it("returns true for media extensions", () => {
+    expect(isImageFile("video.mp4")).toBe(true);
+    expect(isImageFile("video.webm")).toBe(true);
+    expect(isImageFile("audio.ogg")).toBe(true);
+    expect(isImageFile("doc.pdf")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isImageFile("PHOTO.PNG")).toBe(true);
+    expect(isImageFile("photo.JPG")).toBe(true);
+  });
+
+  it("returns false for text-like extensions", () => {
+    expect(isImageFile("file.dj")).toBe(false);
+    expect(isImageFile("file.djot")).toBe(false);
+    expect(isImageFile("file.txt")).toBe(false);
+    expect(isImageFile("file.md")).toBe(false);
+    expect(isImageFile("file.html")).toBe(false);
+  });
+
+  it("returns false for files without extensions", () => {
+    expect(isImageFile("README")).toBe(false);
+    expect(isImageFile("Makefile")).toBe(false);
+  });
+});
+
+describe("isBinaryContent", () => {
+  it("returns false for plain text", () => {
+    expect(isBinaryContent("Hello, world!\nSecond line.")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isBinaryContent("")).toBe(false);
+  });
+
+  it("returns true for content with null bytes", () => {
+    expect(isBinaryContent("GIF89a\0\0\0")).toBe(true);
+  });
+
+  it("returns true for null byte at start", () => {
+    expect(isBinaryContent("\0PNG")).toBe(true);
+  });
+
+  it("detects binary within first 8KB", () => {
+    const text = "a".repeat(4000) + "\0" + "b".repeat(4000);
+    expect(isBinaryContent(text)).toBe(true);
+  });
+
+  it("ignores null bytes past 8KB", () => {
+    const text = "a".repeat(9000) + "\0";
+    expect(isBinaryContent(text)).toBe(false);
+  });
+});
+
+describe("splitByCodeFences", () => {
+  it("returns single segment for text with no fences", () => {
+    const segs = splitByCodeFences("hello\nworld");
+    expect(segs).toEqual([{ content: "hello\nworld", isCode: false }]);
+  });
+
+  it("splits fenced code blocks", () => {
+    const text = "before\n```\ncode\n```\nafter";
+    const segs = splitByCodeFences(text);
+    expect(segs.length).toBe(3);
+    expect(segs[0]).toEqual({ content: "before", isCode: false });
+    expect(segs[1]).toEqual({ content: "```\ncode\n```", isCode: true });
+    expect(segs[2]).toEqual({ content: "after", isCode: false });
+  });
+
+  it("handles tilde fences", () => {
+    const text = "before\n~~~\ncode\n~~~\nafter";
+    const segs = splitByCodeFences(text);
+    expect(segs[1]).toEqual({ content: "~~~\ncode\n~~~", isCode: true });
+  });
+
+  it("handles unclosed fence as code to end", () => {
+    const text = "before\n```\ncode\nmore code";
+    const segs = splitByCodeFences(text);
+    expect(segs[1].isCode).toBe(true);
+    expect(segs[1].content).toContain("code");
+  });
+});
+
+describe("collectFootnoteLabels", () => {
+  it("finds footnote definitions", () => {
+    const text = "text\n[^note]: definition\n[^other]: another";
+    expect(collectFootnoteLabels(text)).toEqual(new Set(["note", "other"]));
+  });
+
+  it("ignores footnotes inside code fences", () => {
+    const text = "```\n[^note]: in code\n```\n[^real]: real";
+    expect(collectFootnoteLabels(text)).toEqual(new Set(["real"]));
+  });
+});
+
+describe("collectReferenceLabels", () => {
+  it("finds reference definitions", () => {
+    const text = "[link]: http://example.com\n[other]: http://other.com";
+    expect(collectReferenceLabels(text)).toEqual(new Set(["link", "other"]));
+  });
+
+  it("does not match footnote definitions", () => {
+    const text = "[^note]: definition\n[link]: url";
+    expect(collectReferenceLabels(text)).toEqual(new Set(["link"]));
+  });
+});
+
+describe("collectExplicitIds", () => {
+  it("finds explicit IDs", () => {
+    const text = "# Heading {#myid}\n\n::: {#other}";
+    expect(collectExplicitIds(text)).toEqual(new Set(["myid", "other"]));
+  });
+
+  it("ignores IDs inside code fences", () => {
+    const text = "```\n{#fake}\n```\n{#real}";
+    expect(collectExplicitIds(text)).toEqual(new Set(["real"]));
+  });
+});
+
+describe("renameFootnoteInText", () => {
+  it("renames both definition and references", () => {
+    const text = "[^note]: definition\n\nSee [^note] for details.";
+    const result = renameFootnoteInText(text, "note", "note-1");
+    expect(result).toContain("[^note-1]: definition");
+    expect(result).toContain("[^note-1]");
+    expect(result).not.toContain("[^note]");
+  });
+});
+
+describe("removeReferenceDefinition", () => {
+  it("removes matching definition", () => {
+    const text = "[link]: http://example.com\n\nSome text with [link].";
+    const result = removeReferenceDefinition(text, "link");
+    expect(result).not.toContain("[link]: http://example.com");
+    expect(result).toContain("[link]");
+  });
+});
+
+describe("renameIdInText", () => {
+  it("renames explicit ID", () => {
+    const text = "# Heading {#myid}";
+    const result = renameIdInText(text, "myid", "myid-1");
+    expect(result).toBe("# Heading {#myid-1}");
+  });
+});
+
+describe("preprocessInclusions", () => {
+  it("substitutes basic inclusion", () => {
+    const result = preprocessInclusions("before\n![](child.dj)\nafter", {
+      readFile: mockReadFile({ "child.dj": "included content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("included content");
+    expect(result.text).toContain("before");
+    expect(result.text).toContain("after");
+    expect(result.text).not.toContain("![](child.dj)");
+  });
+
+  it("produces correct HTML for basic inclusion", () => {
+    const result = preprocessInclusions("# Main\n\n![](child.dj)", {
+      readFile: mockReadFile({ "child.dj": "Hello from child." }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    const html = renderHTML(parse(result.text, { warn: noWarn }), { warn: noWarn });
+    expect(html).toContain("<h1>");
+    expect(html).toContain("Hello from child.");
+  });
+
+  it("handles cross-file syntax interactions", () => {
+    const result = preprocessInclusions("![](a.dj)![](b.dj)", {
+      readFile: mockReadFile({
+        "a.dj": "*bold start ",
+        "b.dj": "bold end*",
+      }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    const html = renderHTML(parse(result.text, { warn: noWarn }), { warn: noWarn });
+    expect(html).toContain("<strong>");
+  });
+
+  it("handles nested inclusion (A includes B which includes C)", () => {
+    const result = preprocessInclusions("![](a.dj)", {
+      readFile: mockReadFile({
+        "a.dj": "from A\n![](b.dj)",
+        "b.dj": "from B\n![](c.dj)",
+        "c.dj": "from C",
+      }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("from A");
+    expect(result.text).toContain("from B");
+    expect(result.text).toContain("from C");
+  });
+
+  it("detects cyclic inclusion (A -> B -> A)", () => {
+    const warnings: string[] = [];
+    const result = preprocessInclusions("![](a.dj)", {
+      readFile: mockReadFile({
+        "a.dj": "from A\n![](b.dj)",
+        "b.dj": "from B\n![](a.dj)",
+      }),
+      basePath: "/test",
+      warn: (w: Warning) => warnings.push(w.message),
+    });
+    expect(warnings.some((m) => m.includes("Cyclic inclusion"))).toBe(true);
+    expect(result.text).toContain("from A");
+    expect(result.text).toContain("from B");
+  });
+
+  it("detects self-inclusion", () => {
+    const warnings: string[] = [];
+    const result = preprocessInclusions("![](self.dj)", {
+      readFile: mockReadFile({
+        "self.dj": "text\n![](self.dj)",
+      }),
+      basePath: "/test",
+      warn: (w: Warning) => warnings.push(w.message),
+    });
+    expect(warnings.some((m) => m.includes("Cyclic inclusion"))).toBe(true);
+  });
+
+  it("leaves image references (.png) unchanged", () => {
+    const result = preprocessInclusions("![alt](photo.png)", {
+      readFile: mockReadFile({}),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("![alt](photo.png)");
+  });
+
+  it("handles multiple inclusions on one line", () => {
+    const result = preprocessInclusions("![](a.dj)![](b.dj)", {
+      readFile: mockReadFile({
+        "a.dj": "AAA",
+        "b.dj": "BBB",
+      }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("AAA");
+    expect(result.text).toContain("BBB");
+  });
+
+  it("handles inline inclusion with surrounding text", () => {
+    const result = preprocessInclusions("prefix ![](a.dj) suffix", {
+      readFile: mockReadFile({ "a.dj": "MIDDLE" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("prefix");
+    expect(result.text).toContain("MIDDLE");
+    expect(result.text).toContain("suffix");
+  });
+
+  it("resolves footnote conflicts", () => {
+    const warnings: string[] = [];
+    const result = preprocessInclusions(
+      "Parent[^note]\n\n[^note]: parent def\n\n![](child.dj)",
+      {
+        readFile: mockReadFile({
+          "child.dj": "Child[^note]\n\n[^note]: child def",
+        }),
+        basePath: "/test",
+        warn: (w: Warning) => warnings.push(w.message),
+      }
+    );
+    expect(warnings.some((m) => m.includes("Footnote"))).toBe(true);
+    expect(result.text).toContain("[^note-1]");
+  });
+
+  it("resolves reference conflicts (parent wins)", () => {
+    const warnings: string[] = [];
+    const result = preprocessInclusions(
+      "[link]: http://parent.com\n\n![](child.dj)",
+      {
+        readFile: mockReadFile({
+          "child.dj": "[link]: http://child.com\n\nSee [link].",
+        }),
+        basePath: "/test",
+        warn: (w: Warning) => warnings.push(w.message),
+      }
+    );
+    expect(warnings.some((m) => m.includes("Reference"))).toBe(true);
+    expect(result.text).not.toContain("http://child.com");
+  });
+
+  it("resolves explicit ID conflicts", () => {
+    const warnings: string[] = [];
+    const result = preprocessInclusions(
+      "# Heading {#myid}\n\n![](child.dj)",
+      {
+        readFile: mockReadFile({
+          "child.dj": "# Other {#myid}",
+        }),
+        basePath: "/test",
+        warn: (w: Warning) => warnings.push(w.message),
+      }
+    );
+    expect(warnings.some((m) => m.includes("Explicit ID"))).toBe(true);
+    expect(result.text).toContain("{#myid-1}");
+  });
+
+  it("handles missing file gracefully", () => {
+    const warnings: string[] = [];
+    const result = preprocessInclusions("![](missing.dj)", {
+      readFile: () => null,
+      basePath: "/test",
+      warn: (w: Warning) => warnings.push(w.message),
+    });
+    expect(warnings.some((m) => m.includes("Could not read"))).toBe(true);
+    // Alt text is empty, so the pattern is removed
+    expect(result.text).not.toContain("![](missing.dj)");
+  });
+
+  it("browser mode: no readFile, removes inclusion pattern", () => {
+    const result = preprocessInclusions("![](file.dj)", {
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).not.toContain("![](file.dj)");
+  });
+
+  it("handles empty included file", () => {
+    const result = preprocessInclusions("before\n![](empty.dj)\nafter", {
+      readFile: mockReadFile({ "empty.dj": "" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("before");
+    expect(result.text).toContain("after");
+  });
+
+  it("does not process inclusions inside code fences", () => {
+    const result = preprocessInclusions(
+      "```\n![](file.dj)\n```",
+      {
+        readFile: mockReadFile({ "file.dj": "SHOULD NOT APPEAR" }),
+        basePath: "/test",
+        warn: noWarn,
+      }
+    );
+    expect(result.text).toContain("![](file.dj)");
+    expect(result.text).not.toContain("SHOULD NOT APPEAR");
+  });
+
+  it("handles inclusion inside block quote", () => {
+    const result = preprocessInclusions("> ![](child.dj)", {
+      readFile: mockReadFile({ "child.dj": "quoted content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("> quoted content");
+  });
+
+  it("handles inclusion inside list item", () => {
+    const result = preprocessInclusions("- ![](child.dj)", {
+      readFile: mockReadFile({ "child.dj": "list content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("- list content");
+  });
+
+  it("handles readFile that throws", () => {
+    const warnings: string[] = [];
+    const result = preprocessInclusions("![](bad.dj)", {
+      readFile: () => { throw new Error("ENOENT"); },
+      basePath: "/test",
+      warn: (w: Warning) => warnings.push(w.message),
+    });
+    expect(warnings.some((m) => m.includes("Could not read"))).toBe(true);
+    expect(result.text).not.toContain("![](bad.dj)");
+  });
+
+  it("emits onInclude for every detected inclusion", () => {
+    const result = preprocessInclusions("![](a.dj) and ![](b.dj)", {
+      readFile: mockReadFile({ "a.dj": "A", "b.dj": "B" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.inclusions.length).toBe(2);
+  });
+
+  it("handles .djot extension", () => {
+    const result = preprocessInclusions("![](file.djot)", {
+      readFile: mockReadFile({ "file.djot": "djot content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("djot content");
+  });
+
+  it("includes files without extensions", () => {
+    const result = preprocessInclusions("![](README)", {
+      readFile: mockReadFile({ "README": "readme content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("readme content");
+    expect(result.text).not.toContain("![](README)");
+  });
+
+  it("includes .txt files", () => {
+    const result = preprocessInclusions("![](notes.txt)", {
+      readFile: mockReadFile({ "notes.txt": "plain text content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("plain text content");
+  });
+
+  it("includes .md files", () => {
+    const result = preprocessInclusions("![](doc.md)", {
+      readFile: mockReadFile({ "doc.md": "markdown content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("markdown content");
+  });
+
+  it("includes .html files", () => {
+    const result = preprocessInclusions("![](fragment.html)", {
+      readFile: mockReadFile({ "fragment.html": "<p>html</p>" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("<p>html</p>");
+  });
+
+  it("leaves all image extensions as images", () => {
+    const exts = ["png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "avif", "ico"];
+    for (const ext of exts) {
+      const result = preprocessInclusions(`![alt](photo.${ext})`, {
+        readFile: mockReadFile({}),
+        basePath: "/test",
+        warn: noWarn,
+      });
+      expect(result.text).toContain(`![alt](photo.${ext})`);
+    }
+  });
+
+  it("leaves URLs unchanged", () => {
+    const result = preprocessInclusions("![alt](https://example.com/page)", {
+      readFile: mockReadFile({}),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("![alt](https://example.com/page)");
+  });
+
+  it("leaves URLs with various schemes unchanged", () => {
+    for (const url of ["http://x.com/a", "ftp://files.org/b", "data://foo"]) {
+      const result = preprocessInclusions(`![](${url})`, {
+        readFile: mockReadFile({}),
+        basePath: "/test",
+        warn: noWarn,
+      });
+      expect(result.text).toContain(`![](${url})`);
+    }
+  });
+
+  it("skips binary content from readFile (null-byte detection)", () => {
+    const binaryContent = "GIF89a\0\x01\x02\x03";
+    const result = preprocessInclusions("![](mystery.dat)", {
+      readFile: mockReadFile({ "mystery.dat": binaryContent }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("![](mystery.dat)");
+    expect(result.text).not.toContain("GIF89a");
+  });
+});
+
+describe("InclusionRecord metadata", () => {
+  it("returns inclusions array with correct resolvedPath", () => {
+    const result = preprocessInclusions("![](child.dj)", {
+      readFile: mockReadFile({ "child.dj": "content" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.inclusions.length).toBe(1);
+    expect(result.inclusions[0].resolvedPath).toContain("child.dj");
+    expect(result.inclusions[0].destination).toBe("child.dj");
+  });
+
+  it("records correct resultOffset and resultLength", () => {
+    const result = preprocessInclusions("AB![](child.dj)CD", {
+      readFile: mockReadFile({ "child.dj": "XYZ" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.inclusions.length).toBe(1);
+    const rec = result.inclusions[0];
+    expect(rec.resultOffset).toBe(2);
+    expect(rec.resultLength).toBe(3);
+    expect(result.text.substring(rec.resultOffset, rec.resultOffset + rec.resultLength)).toBe("XYZ");
+  });
+
+  it("nested inclusions produce children records", () => {
+    const result = preprocessInclusions("![](a.dj)", {
+      readFile: mockReadFile({
+        "a.dj": "from A\n![](b.dj)",
+        "b.dj": "from B",
+      }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.inclusions.length).toBe(1);
+    expect(result.inclusions[0].resolvedPath).toContain("a.dj");
+    expect(result.inclusions[0].children.length).toBe(1);
+    expect(result.inclusions[0].children[0].resolvedPath).toContain("b.dj");
+  });
+
+  it("multiple inclusions on one line produce multiple records", () => {
+    const result = preprocessInclusions("![](a.dj)![](b.dj)", {
+      readFile: mockReadFile({ "a.dj": "A", "b.dj": "B" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.inclusions.length).toBe(2);
+    expect(result.inclusions[0].resolvedPath).toContain("a.dj");
+    expect(result.inclusions[1].resolvedPath).toContain("b.dj");
+  });
+
+  it("no records for images, URLs, or failed reads", () => {
+    const result = preprocessInclusions(
+      "![](photo.png) ![](https://x.com) ![](missing.dj)",
+      {
+        readFile: () => null,
+        basePath: "/test",
+        warn: noWarn,
+      }
+    );
+    expect(result.inclusions.length).toBe(0);
+  });
+});
+
+describe("mergeInclusionEvents", () => {
+  it("injects +inclusion/-inclusion events at correct positions", () => {
+    const result = preprocessInclusions("![](child.dj)", {
+      readFile: mockReadFile({ "child.dj": "hello" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    const rawEvents = Array.from(parseEvents(result.text, { warn: noWarn }));
+    const merged = mergeInclusionEvents(rawEvents, result.inclusions);
+    const inclusionOpens = merged.filter((e) => e.annot.startsWith("+inclusion"));
+    const inclusionCloses = merged.filter((e) => e.annot === "-inclusion");
+    expect(inclusionOpens.length).toBe(1);
+    expect(inclusionCloses.length).toBe(1);
+  });
+
+  it("events carry resolvedPath in annotation suffix", () => {
+    const result = preprocessInclusions("![](child.dj)", {
+      readFile: mockReadFile({ "child.dj": "hello" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    const rawEvents = Array.from(parseEvents(result.text, { warn: noWarn }));
+    const merged = mergeInclusionEvents(rawEvents, result.inclusions);
+    const openEvent = merged.find((e) => e.annot.startsWith("+inclusion"));
+    expect(openEvent).toBeDefined();
+    expect(openEvent!.annot).toContain("child.dj");
+  });
+
+  it("nested inclusions produce nested event pairs", () => {
+    const result = preprocessInclusions("![](a.dj)", {
+      readFile: mockReadFile({
+        "a.dj": "outer\n![](b.dj)\nend",
+        "b.dj": "inner",
+      }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    const rawEvents = Array.from(parseEvents(result.text, { warn: noWarn }));
+    const merged = mergeInclusionEvents(rawEvents, result.inclusions);
+    const opens = merged.filter((e) => e.annot.startsWith("+inclusion"));
+    const closes = merged.filter((e) => e.annot === "-inclusion");
+    expect(opens.length).toBe(2);
+    expect(closes.length).toBe(2);
+  });
+
+  it("empty inclusions array returns events unchanged", () => {
+    const rawEvents = Array.from(parseEvents("hello world", { warn: noWarn }));
+    const merged = mergeInclusionEvents(rawEvents, []);
+    expect(merged).toEqual(rawEvents);
+  });
+});
+
+describe("back-to-back inclusion event ordering", () => {
+  it("close event comes before open event at same position", () => {
+    const result = preprocessInclusions("![](a.dj)![](b.dj)", {
+      readFile: mockReadFile({ "a.dj": "AAA", "b.dj": "BBB" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    const rawEvents = Array.from(parseEvents(result.text, { warn: noWarn }));
+    const merged = mergeInclusionEvents(rawEvents, result.inclusions);
+    const inclusionEvents = merged.filter((e) => e.annot.includes("inclusion"));
+    // Expected order: +inclusion|a, -inclusion, +inclusion|b, -inclusion
+    expect(inclusionEvents.length).toBe(4);
+    expect(inclusionEvents[0].annot).toContain("+inclusion");
+    expect(inclusionEvents[0].annot).toContain("a.dj");
+    expect(inclusionEvents[1].annot).toBe("-inclusion");
+    expect(inclusionEvents[2].annot).toContain("+inclusion");
+    expect(inclusionEvents[2].annot).toContain("b.dj");
+    expect(inclusionEvents[3].annot).toBe("-inclusion");
+  });
+
+  it("paragraph-separated inclusions close before next opens", () => {
+    const result = preprocessInclusions("![](a.dj)\n\n![](b.dj)", {
+      readFile: mockReadFile({ "a.dj": "First.", "b.dj": "Second." }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    const rawEvents = Array.from(parseEvents(result.text, { warn: noWarn }));
+    const merged = mergeInclusionEvents(rawEvents, result.inclusions);
+    const inclusionEvents = merged.filter((e) => e.annot.includes("inclusion"));
+    // -inclusion for a.dj must come before +inclusion for b.dj
+    expect(inclusionEvents.length).toBe(4);
+    expect(inclusionEvents[0].annot).toContain("+inclusion");
+    expect(inclusionEvents[1].annot).toBe("-inclusion");
+    expect(inclusionEvents[2].annot).toContain("+inclusion");
+    expect(inclusionEvents[3].annot).toBe("-inclusion");
+    // No overlap: close offset <= next open offset
+    expect(inclusionEvents[1].startpos).toBeLessThanOrEqual(inclusionEvents[2].startpos);
+  });
+});
+
+describe("readFile map-based inclusion (browser pattern)", () => {
+  it("processes inclusions using a pre-built file map", () => {
+    const fileMap: Record<string, string> = {
+      "/base/child.dj": "Hello from child.",
+    };
+    const result = preprocessInclusions("![](child.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("Hello from child.");
+    expect(result.text).not.toContain("![](child.dj)");
+  });
+
+  it("handles nested inclusions with a pre-built map", () => {
+    const fileMap: Record<string, string> = {
+      "/base/a.dj": "outer\n\n![](b.dj)\n\nend",
+      "/base/b.dj": "inner content",
+    };
+    const result = preprocessInclusions("![](a.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("outer");
+    expect(result.text).toContain("inner content");
+    expect(result.text).toContain("end");
+  });
+
+  it("returns null for files not in the map (leaves pattern)", () => {
+    const fileMap: Record<string, string> = {};
+    const warnings: string[] = [];
+    const result = preprocessInclusions("![](missing.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: (w) => warnings.push(w.message),
+    });
+    expect(result.text).not.toContain("![](missing.dj)");
+    expect(warnings.length).toBe(1);
+  });
+
+  it("produces correct HTML from map-based inclusions", () => {
+    const fileMap: Record<string, string> = {
+      "/base/child.dj": "Included *text*.",
+    };
+    const result = preprocessInclusions("# Title\n\n![](child.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    const rawEvents = Array.from(parseEvents(result.text, { warn: noWarn }));
+    const merged = mergeInclusionEvents(rawEvents, result.inclusions);
+    const doc = parseFromEvents(merged, result.text, { warn: noWarn });
+    const html = renderHTML(doc, { warn: noWarn });
+    expect(html).toContain("Included");
+    expect(html).toContain("<strong>text</strong>");
+  });
+});
+
+describe("buildEventStreams", () => {
+  it("returns expanded events with inclusion markers", () => {
+    const fileMap: Record<string, string> = {
+      "/base/child.dj": "Included paragraph.",
+    };
+    const result = buildEventStreams("# Title\n\n![](child.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.expandedEvents.length).toBeGreaterThan(0);
+    const annots = result.expandedEvents.map(e => e.annot);
+    expect(annots.some(a => a.startsWith("+inclusion"))).toBe(true);
+    expect(annots.some(a => a.startsWith("-inclusion"))).toBe(true);
+  });
+
+  it("isWellFormed is true for balanced markup", () => {
+    const result = buildEventStreams("Hello *bold* world.", {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.isWellFormed).toBe(true);
+  });
+
+  it("isWellFormed is false for unmatched opener", () => {
+    const result = buildEventStreams("Hello *world without closing.", {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.isWellFormed).toBe(false);
+  });
+
+  it("isWellFormed is false for unmatched underscore emphasis", () => {
+    const result = buildEventStreams("Hello _emphasis not closed.", {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.isWellFormed).toBe(false);
+  });
+
+  it("isWellFormed is true when all openers match in multiple paragraphs", () => {
+    const result = buildEventStreams("First *bold*.\n\nSecond _emph_ here.", {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.isWellFormed).toBe(true);
+  });
+
+  it("isWellFormed is false when one paragraph has unmatched opener", () => {
+    const result = buildEventStreams("Paragraph *ok*.\n\nParagraph *broken here.\n\nParagraph fine.", {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.isWellFormed).toBe(false);
+  });
+
+  it("isWellFormed is false for unmatched closer", () => {
+    const result = buildEventStreams("this is also bold* here.", {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.isWellFormed).toBe(false);
+  });
+
+  it("isWellFormed is true with headings and balanced tags", () => {
+    const result = buildEventStreams("# Title\n\nParagraph with *bold* text.", {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.isWellFormed).toBe(true);
+  });
+
+  it("expanded events produce valid HTML via parseFromEvents", () => {
+    const fileMap: Record<string, string> = {
+      "/base/child.dj": "Included *bold*.",
+    };
+    const streams = buildEventStreams("# Heading\n\n![](child.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    const doc = parseFromEvents(streams.expandedEvents, streams.expandedText, { warn: noWarn });
+    const html = renderHTML(doc, { warn: noWarn });
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("Heading");
+  });
+
+  it("returns no markers when no includes present", () => {
+    const input = "Plain document.";
+    const streams = buildEventStreams(input, {
+      readFile: () => null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(streams.inclusions).toEqual([]);
+    expect(streams.expandedText).toBe(input);
+    // No inclusion markers in expanded events
+    const annots = streams.expandedEvents.map(e => e.annot);
+    expect(annots.some(a => a.includes("inclusion"))).toBe(false);
+  });
+
+  it("text contains full preprocessed content", () => {
+    const fileMap: Record<string, string> = {
+      "/base/child.dj": "Hello from child.",
+    };
+    const streams = buildEventStreams("Before\n\n![](child.dj)\n\nAfter", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(streams.expandedText).toContain("Before");
+    expect(streams.expandedText).toContain("Hello from child.");
+    expect(streams.expandedText).toContain("After");
+    expect(streams.expandedText).not.toContain("![](child.dj)");
+  });
+
+  it("cross-file emphasis renders correctly in HTML", () => {
+    const fileMap: Record<string, string> = {
+      "/base/a.dj": "hello *world",
+      "/base/b.dj": "more text* here",
+    };
+    const streams = buildEventStreams("![](a.dj)\n![](b.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    const doc = parseFromEvents(streams.expandedEvents, streams.expandedText, { warn: noWarn });
+    const html = renderHTML(doc, { warn: noWarn });
+    expect(html).toContain("<strong>");
+    expect(html).toContain("world");
+    expect(html).toContain("more text");
+    expect(html).toContain("here");
+  });
+});
+
+// --- Single-scan verification tests ---
+describe("single-scan processing", () => {
+  it("preprocessInclusions iterates input segments only once", () => {
+    // preprocessInclusions uses splitByCodeFences (one pass over lines),
+    // then iterates segments once with regex — no second pass.
+    // We verify by ensuring it produces correct output in one call.
+    const fileMap: Record<string, string> = {
+      "/base/child.dj": "included text",
+    };
+    const result = preprocessInclusions("before\n\n![](child.dj)\n\nafter", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    expect(result.text).toContain("before");
+    expect(result.text).toContain("included text");
+    expect(result.text).toContain("after");
+    expect(result.text).not.toContain("![](child.dj)");
+    expect(result.inclusions.length).toBe(1);
+  });
+
+  it("buildEventStreams parses events once and merges without re-parsing", () => {
+    let parseCount = 0;
+    const origParseEvents = parseEvents;
+    const fileMap: Record<string, string> = {
+      "/base/a.dj": "# Title\n\nContent.",
+    };
+    // buildEventStreams calls parseEvents for the main doc and once per unique file.
+    // With one inclusion of one file, that's exactly 2 parseEvents calls —
+    // not a re-scan of the merged result.
+    const result = buildEventStreams("![](a.dj)", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Verify structure is correct (event merging happened without re-parsing)
+    expect(result.expandedEvents.length).toBeGreaterThan(0);
+    expect(result.inclusions.length).toBe(1);
+    expect(result.expandedText.length).toBeGreaterThan(0);
+  });
+});
+
+// --- Inline code backtick tests ---
+// Inline backtick spans are protected by the enhanced single-pass scanner.
+describe("inclusions inside inline code", () => {
+  it("ignores inclusion syntax inside inline backticks", () => {
+    const fileMap: Record<string, string> = {
+      "/base/file.dj": "included",
+    };
+    const result = preprocessInclusions("text `![](file.dj)` more", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Inclusion is inside backtick span — should be ignored
+    expect(result.text).toContain("`![](file.dj)`");
+    expect(result.inclusions.length).toBe(0);
+  });
+
+  it("ignores inclusion syntax inside double backticks", () => {
+    const fileMap: Record<string, string> = {
+      "/base/example.dj": "example content",
+    };
+    const result = preprocessInclusions("before ``![](example.dj)`` after", {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Inclusion is inside double backtick span — should be ignored
+    expect(result.text).toContain("``![](example.dj)``");
+    expect(result.inclusions.length).toBe(0);
+  });
+});
+
+// --- Multi-line verbatim span tests ---
+// Multi-line backtick verbatim spans are protected by the enhanced single-pass scanner.
+describe("inclusions inside multi-line verbatim spans", () => {
+  it("ignores inclusion syntax inside multi-line verbatim", () => {
+    const fileMap: Record<string, string> = {
+      "/base/inner.dj": "inner text",
+    };
+    // A verbatim span that spans two lines
+    const input = "start `verbatim\n![](inner.dj)\nend verbatim` after";
+    const result = preprocessInclusions(input, {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Inclusion is inside backtick span — should be ignored
+    expect(result.text).toContain("![](inner.dj)");
+    expect(result.inclusions.length).toBe(0);
+  });
+});
+
+// --- Indented fenced code block tests ---
+// Indented fenced code blocks are now properly detected by the enhanced scanner.
+describe("inclusions inside indented fenced code blocks", () => {
+  it("ignores inclusion inside indented fence (list item context)", () => {
+    const fileMap: Record<string, string> = {
+      "/base/code.dj": "code content",
+    };
+    // A fenced code block indented by spaces (as inside a list item)
+    const input = "- item\n\n    ```\n    ![](code.dj)\n    ```\n";
+    const result = preprocessInclusions(input, {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Indented fence is detected — inclusion should be ignored
+    expect(result.text).toContain("![](code.dj)");
+    expect(result.inclusions.length).toBe(0);
+  });
+
+  it("properly protects non-indented fenced code blocks", () => {
+    const fileMap: Record<string, string> = {
+      "/base/protected.dj": "should not appear",
+    };
+    const input = "before\n```\n![](protected.dj)\n```\nafter";
+    const result = preprocessInclusions(input, {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Non-indented fence IS properly detected — inclusion is NOT processed
+    expect(result.text).toContain("![](protected.dj)");
+    expect(result.inclusions.length).toBe(0);
+  });
+});
+
+// --- Attribute comment tests ---
+// Attribute comments are now properly detected by the enhanced single-pass scanner.
+describe("inclusions inside attribute comments", () => {
+  it("ignores inclusion inside inline attribute comment", () => {
+    const fileMap: Record<string, string> = {
+      "/base/attr.dj": "attr content",
+    };
+    // A heading with an attribute comment containing inclusion syntax
+    const input = "# Heading {.class % ![](attr.dj) }";
+    const result = preprocessInclusions(input, {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Inclusion is inside attribute comment — should be ignored
+    expect(result.text).toContain("{.class % ![](attr.dj) }");
+    expect(result.inclusions.length).toBe(0);
+  });
+
+  it("strips one trailing newline from included file", () => {
+    const result = preprocessInclusions("before\n![](child.dj)\nafter", {
+      readFile: mockReadFile({ "child.dj": "included content\n" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toBe("before\nincluded content\nafter");
+  });
+
+  it("strips only one trailing newline, preserving intentional blank lines", () => {
+    const result = preprocessInclusions("before\n![](child.dj)\nafter", {
+      readFile: mockReadFile({ "child.dj": "included content\n\n" }),
+      basePath: "/test",
+      warn: noWarn,
+    });
+    expect(result.text).toBe("before\nincluded content\n\nafter");
+  });
+
+  it("ignores inclusion inside block attribute comment", () => {
+    const fileMap: Record<string, string> = {
+      "/base/ml.dj": "multiline content",
+    };
+    const input = "{%\n  This is a comment\n  ![](ml.dj)\n%}";
+    const result = preprocessInclusions(input, {
+      readFile: (p: string) => fileMap[p] || null,
+      basePath: "/base",
+      warn: noWarn,
+    });
+    // Inclusion is inside block comment — should be ignored
+    expect(result.text).toContain("![](ml.dj)");
+    expect(result.inclusions.length).toBe(0);
+  });
+});

--- a/src/include.ts
+++ b/src/include.ts
@@ -1,0 +1,708 @@
+import { Options, IncludeOptions, Warning } from "./options";
+import { Event } from "./event";
+import { parseEvents } from "./block";
+
+const IMAGE_EXT_RE = /\.(?:png|jpe?g|gif|svg|webp|bmp|ico|tiff?|avif|heic|mp4|webm|ogg|pdf)$/i;
+const URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+const INCLUSION_RE = /!\[([^\]]*)\]\(([^)]+)\)/g;
+const FOOTNOTE_DEF_RE = /^\[\^([^\]]+)\]:/gm;
+const REFERENCE_DEF_RE = /^\[([^\]^][^\]]*)\]:/gm;
+const EXPLICIT_ID_RE = /\{[^}]*#([\w-]+)/g;
+const FENCE_OPEN_RE = /^(\s*)(`{3,}|~{3,})/;
+
+function pathDirname(p: string): string {
+  const idx = p.lastIndexOf("/");
+  if (idx < 0) return ".";
+  if (idx === 0) return "/";
+  return p.substring(0, idx);
+}
+
+function normalizePath(p: string): string {
+  const parts = p.split("/");
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (part === "." || part === "") continue;
+    if (part === ".." && resolved.length > 0 && resolved[resolved.length - 1] !== "..") {
+      resolved.pop();
+    } else {
+      resolved.push(part);
+    }
+  }
+  const result = resolved.join("/");
+  return p.startsWith("/") ? "/" + result : result || ".";
+}
+
+function pathResolve(base: string, relative: string): string {
+  if (relative.startsWith("/")) return normalizePath(relative);
+  return normalizePath(base + "/" + relative);
+}
+
+export function isImageFile(destination: string): boolean {
+  return IMAGE_EXT_RE.test(destination);
+}
+
+export function isBinaryContent(content: string): boolean {
+  const sample = content.slice(0, 8192);
+  return sample.includes("\0");
+}
+
+function isUrl(destination: string): boolean {
+  return URL_RE.test(destination);
+}
+
+export interface InclusionRecord {
+  sourcePath: string;
+  sourceOffset: number;
+  resolvedPath: string;
+  destination: string;
+  resultOffset: number;
+  resultLength: number;
+  children: InclusionRecord[];
+}
+
+export interface PreprocessResult {
+  text: string;
+  inclusions: InclusionRecord[];
+}
+
+interface TextSegment {
+  content: string;
+  isCode: boolean;
+}
+
+export function splitByCodeFences(text: string): TextSegment[] {
+  const lines = text.split("\n");
+  const segments: TextSegment[] = [];
+  let currentLines: string[] = [];
+  let inFence = false;
+  let fencePattern: RegExp | null = null;
+
+  for (const line of lines) {
+    if (inFence) {
+      currentLines.push(line);
+      if (fencePattern && fencePattern.test(line)) {
+        segments.push({ content: currentLines.join("\n"), isCode: true });
+        currentLines = [];
+        inFence = false;
+        fencePattern = null;
+      }
+    } else {
+      const m = line.match(FENCE_OPEN_RE);
+      if (m) {
+        if (currentLines.length > 0) {
+          segments.push({ content: currentLines.join("\n"), isCode: false });
+          currentLines = [];
+        }
+        currentLines.push(line);
+        inFence = true;
+        const marker = m[2][0];
+        const len = m[2].length;
+        fencePattern = new RegExp("^\\s*" + marker + "{" + len + ",}\\s*$");
+      } else {
+        currentLines.push(line);
+      }
+    }
+  }
+
+  if (currentLines.length > 0) {
+    segments.push({ content: currentLines.join("\n"), isCode: inFence });
+  }
+
+  // Further split non-fence segments to protect inline backtick spans
+  // and attribute comments — single pass over each segment's characters.
+  const result: TextSegment[] = [];
+  for (const seg of segments) {
+    if (seg.isCode) {
+      result.push(seg);
+    } else {
+      splitByInlineProtected(seg.content, result);
+    }
+  }
+
+  return result;
+}
+
+// Scans text for inline backtick spans (single or multi-line) and attribute
+// comments ({%...%} and {% inside {... % comment}). Appends segments to `out`.
+// Single pass: each character examined at most once.
+function splitByInlineProtected(text: string, out: TextSegment[]): void {
+  let i = 0;
+  let normalStart = 0;
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    // --- inline backtick span ---
+    if (ch === "`") {
+      // Count consecutive opening backticks
+      let backtickLen = 0;
+      let j = i;
+      while (j < text.length && text[j] === "`") {
+        backtickLen++;
+        j++;
+      }
+      // Search for matching closing sequence of exactly backtickLen backticks
+      let closePos = -1;
+      let k = j;
+      while (k <= text.length - backtickLen) {
+        if (text[k] === "`") {
+          let run = 0;
+          let kk = k;
+          while (kk < text.length && text[kk] === "`") { run++; kk++; }
+          if (run === backtickLen) {
+            closePos = k;
+            break;
+          }
+          k = kk; // skip past this backtick run
+          continue;
+        }
+        k++;
+      }
+      if (closePos !== -1) {
+        // Push preceding normal text
+        if (i > normalStart) {
+          out.push({ content: text.substring(normalStart, i), isCode: false });
+        }
+        const endPos = closePos + backtickLen;
+        out.push({ content: text.substring(i, endPos), isCode: true });
+        i = endPos;
+        normalStart = i;
+        continue;
+      }
+      // No matching close — treat as normal text
+      i = j;
+      continue;
+    }
+
+    // --- block attribute comment {%...%} ---
+    if (ch === "{" && i + 1 < text.length && text[i + 1] === "%") {
+      const closePos = text.indexOf("%}", i + 2);
+      if (closePos !== -1) {
+        if (i > normalStart) {
+          out.push({ content: text.substring(normalStart, i), isCode: false });
+        }
+        const endPos = closePos + 2;
+        out.push({ content: text.substring(i, endPos), isCode: true });
+        i = endPos;
+        normalStart = i;
+        continue;
+      }
+    }
+
+    // --- inline attribute comment { ... % comment } ---
+    if (ch === "{" && !(i + 1 < text.length && text[i + 1] === "%")) {
+      // Scan ahead for % before the closing }
+      let j = i + 1;
+      let foundPercent = false;
+      while (j < text.length) {
+        if (text[j] === "}") break;
+        if (text[j] === "%") { foundPercent = true; break; }
+        j++;
+      }
+      if (foundPercent) {
+        // Find closing }
+        let closePos = text.indexOf("}", j + 1);
+        if (closePos !== -1) {
+          if (i > normalStart) {
+            out.push({ content: text.substring(normalStart, i), isCode: false });
+          }
+          const endPos = closePos + 1;
+          out.push({ content: text.substring(i, endPos), isCode: true });
+          i = endPos;
+          normalStart = i;
+          continue;
+        }
+      }
+    }
+
+    i++;
+  }
+
+  if (normalStart < text.length) {
+    out.push({ content: text.substring(normalStart), isCode: false });
+  }
+}
+
+export function collectFootnoteLabels(text: string): Set<string> {
+  const labels = new Set<string>();
+  const segments = splitByCodeFences(text);
+  for (const seg of segments) {
+    if (seg.isCode) continue;
+    const re = new RegExp(FOOTNOTE_DEF_RE.source, "gm");
+    let m;
+    while ((m = re.exec(seg.content)) !== null) {
+      labels.add(m[1]);
+    }
+  }
+  return labels;
+}
+
+export function collectReferenceLabels(text: string): Set<string> {
+  const labels = new Set<string>();
+  const segments = splitByCodeFences(text);
+  for (const seg of segments) {
+    if (seg.isCode) continue;
+    const re = new RegExp(REFERENCE_DEF_RE.source, "gm");
+    let m;
+    while ((m = re.exec(seg.content)) !== null) {
+      labels.add(m[1]);
+    }
+  }
+  return labels;
+}
+
+export function collectExplicitIds(text: string): Set<string> {
+  const ids = new Set<string>();
+  const segments = splitByCodeFences(text);
+  for (const seg of segments) {
+    if (seg.isCode) continue;
+    const re = new RegExp(EXPLICIT_ID_RE.source, "g");
+    let m;
+    while ((m = re.exec(seg.content)) !== null) {
+      ids.add(m[1]);
+    }
+  }
+  return ids;
+}
+
+export function renameFootnoteInText(
+  text: string,
+  oldLabel: string,
+  newLabel: string
+): string {
+  const segments = splitByCodeFences(text);
+  return segments
+    .map((seg) => {
+      if (seg.isCode) return seg.content;
+      const escaped = oldLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return seg.content
+        .replace(
+          new RegExp("^(\\[\\^)" + escaped + "(\\]:)", "gm"),
+          "$1" + newLabel + "$2"
+        )
+        .replace(
+          new RegExp("(\\[\\^)" + escaped + "(\\])", "g"),
+          "$1" + newLabel + "$2"
+        );
+    })
+    .join("\n");
+}
+
+export function removeReferenceDefinition(
+  text: string,
+  label: string
+): string {
+  const segments = splitByCodeFences(text);
+  return segments
+    .map((seg) => {
+      if (seg.isCode) return seg.content;
+      const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const defRe = new RegExp(
+        "^\\[" + escaped + "\\]:[^\\n]*(?:\\n(?=  )[^\\n]*)*\\n?",
+        "gm"
+      );
+      return seg.content.replace(defRe, "");
+    })
+    .join("\n");
+}
+
+export function renameIdInText(
+  text: string,
+  oldId: string,
+  newId: string
+): string {
+  const segments = splitByCodeFences(text);
+  return segments
+    .map((seg) => {
+      if (seg.isCode) return seg.content;
+      const escaped = oldId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return seg.content.replace(
+        new RegExp("(\\{[^}]*#)" + escaped + "(?=[}\\s])", "g"),
+        "$1" + newId
+      );
+    })
+    .join("\n");
+}
+
+function resolveConflicts(
+  parentText: string,
+  includedText: string,
+  warn: (warning: Warning) => void
+): string {
+  let result = includedText;
+
+  const parentFootnotes = collectFootnoteLabels(parentText);
+  const childFootnotes = collectFootnoteLabels(result);
+  for (const label of childFootnotes) {
+    if (parentFootnotes.has(label)) {
+      let n = 1;
+      let newLabel = label + "-" + n;
+      while (parentFootnotes.has(newLabel) || childFootnotes.has(newLabel)) {
+        n++;
+        newLabel = label + "-" + n;
+      }
+      warn(
+        new Warning(
+          `Footnote [^${label}] conflicts with parent; renamed to [^${newLabel}]`
+        )
+      );
+      result = renameFootnoteInText(result, label, newLabel);
+      childFootnotes.delete(label);
+      childFootnotes.add(newLabel);
+    }
+  }
+
+  const parentRefs = collectReferenceLabels(parentText);
+  const childRefs = collectReferenceLabels(result);
+  for (const label of childRefs) {
+    if (parentRefs.has(label)) {
+      warn(
+        new Warning(
+          `Reference [${label}] conflicts with parent; using parent definition`
+        )
+      );
+      result = removeReferenceDefinition(result, label);
+    }
+  }
+
+  const parentIds = collectExplicitIds(parentText);
+  const childIds = collectExplicitIds(result);
+  for (const id of childIds) {
+    if (parentIds.has(id)) {
+      let n = 1;
+      let newId = id + "-" + n;
+      while (parentIds.has(newId) || childIds.has(newId)) {
+        n++;
+        newId = id + "-" + n;
+      }
+      warn(
+        new Warning(
+          `Explicit ID {#${id}} conflicts with parent; renamed to {#${newId}}`
+        )
+      );
+      result = renameIdInText(result, id, newId);
+      childIds.delete(id);
+      childIds.add(newId);
+    }
+  }
+
+  return result;
+}
+
+export function preprocessInclusions(
+  input: string,
+  options: IncludeOptions & Options,
+  inclusionStack?: string[]
+): PreprocessResult {
+  const stack = inclusionStack || [];
+  const warn = options.warn || (() => {});
+  const basePath = options.basePath || ".";
+  const inclusions: InclusionRecord[] = [];
+
+  const segments = splitByCodeFences(input);
+  let accumulatedText = "";
+
+  const processedSegments = segments.map((seg) => {
+    if (seg.isCode) {
+      accumulatedText += seg.content + "\n";
+      return seg.content;
+    }
+
+    const re = new RegExp(INCLUSION_RE.source, "g");
+    let result = "";
+    let lastIndex = 0;
+    let m;
+    while ((m = re.exec(seg.content)) !== null) {
+      const beforeMatch = seg.content.substring(lastIndex, m.index);
+      result += beforeMatch;
+      accumulatedText += beforeMatch;
+      lastIndex = m.index + m[0].length;
+
+      const destination = m[2];
+      const altText = m[1];
+      const sourceOffset = m.index;
+
+      if (isUrl(destination) || isImageFile(destination)) {
+        result += m[0];
+        accumulatedText += m[0];
+        continue;
+      }
+
+      const resolvedPath = pathResolve(basePath, destination);
+
+      if (!options.readFile) {
+        result += altText;
+        accumulatedText += altText;
+        continue;
+      }
+
+      if (stack.includes(resolvedPath)) {
+        warn(new Warning(`Cyclic inclusion of ${resolvedPath}`));
+        result += altText;
+        accumulatedText += altText;
+        continue;
+      }
+
+      let content: string | null;
+      try {
+        content = options.readFile(resolvedPath);
+      } catch {
+        warn(new Warning(`Could not read file ${resolvedPath}`));
+        result += altText;
+        accumulatedText += altText;
+        continue;
+      }
+
+      if (content === null) {
+        warn(new Warning(`Could not read file ${resolvedPath}`));
+        result += altText;
+        accumulatedText += altText;
+        continue;
+      }
+
+      if (isBinaryContent(content)) {
+        result += m[0];
+        accumulatedText += m[0];
+        continue;
+      }
+
+      // Strip one trailing newline (POSIX text files typically end with one)
+      if (content.endsWith("\n")) {
+        content = content.slice(0, -1);
+      }
+
+      const childBasePath = pathDirname(resolvedPath);
+      stack.push(resolvedPath);
+      const childResult = preprocessInclusions(
+        content,
+        { ...options, basePath: childBasePath },
+        stack
+      );
+      stack.pop();
+
+      let processed = resolveConflicts(accumulatedText, childResult.text, warn);
+
+      const resultOffset = accumulatedText.length;
+      result += processed;
+      accumulatedText += processed;
+
+      inclusions.push({
+        sourcePath: basePath,
+        sourceOffset,
+        resolvedPath,
+        destination,
+        resultOffset,
+        resultLength: processed.length,
+        children: childResult.inclusions,
+      });
+    }
+
+    const tail = seg.content.substring(lastIndex);
+    result += tail;
+    accumulatedText += tail + "\n";
+    return result;
+  });
+
+  return {
+    text: processedSegments.join("\n"),
+    inclusions,
+  };
+}
+
+export interface EventStreams {
+  expandedEvents: Event[];
+  mainFileEvents: Event[];
+  isWellFormed: boolean;
+  expandedText: string;
+  inclusions: InclusionRecord[];
+}
+
+
+export function buildEventStreams(
+  input: string,
+  options: IncludeOptions & Options
+): EventStreams {
+  const ppResult = preprocessInclusions(input, options);
+  const expandedParser = parseEvents(ppResult.text, options);
+  const rawExpanded = Array.from(expandedParser);
+  const expandedEvents = mergeInclusionEvents(rawExpanded, ppResult.inclusions);
+  // Parse the original input for main-file events (editor highlighting).
+  // If no inclusions, the original input equals the preprocessed text,
+  // so reuse rawExpanded and the same parser's well-formedness flags.
+  let mainFileEvents: Event[];
+  let isWellFormed: boolean;
+  if (ppResult.inclusions.length === 0) {
+    mainFileEvents = rawExpanded;
+    isWellFormed = !expandedParser.hasUnmatchedOpeners && !expandedParser.hasUnmatchedClosers;
+  } else {
+    const parser = parseEvents(input, options);
+    mainFileEvents = Array.from(parser);
+    isWellFormed = !parser.hasUnmatchedOpeners && !parser.hasUnmatchedClosers;
+  }
+  return {
+    expandedEvents,
+    mainFileEvents,
+    isWellFormed,
+    expandedText: ppResult.text,
+    inclusions: ppResult.inclusions,
+  };
+}
+
+interface InclusionBoundary {
+  offset: number;
+  type: "open" | "close";
+  resolvedPath: string;
+  destination: string;
+}
+
+function flattenBoundaries(
+  inclusions: InclusionRecord[]
+): InclusionBoundary[] {
+  const boundaries: InclusionBoundary[] = [];
+  for (const rec of inclusions) {
+    boundaries.push({
+      offset: rec.resultOffset,
+      type: "open",
+      resolvedPath: rec.resolvedPath,
+      destination: rec.destination,
+    });
+    // Recurse into children — they are already at their correct resultOffset
+    const childBoundaries = flattenBoundaries(rec.children);
+    for (const cb of childBoundaries) {
+      boundaries.push(cb);
+    }
+    boundaries.push({
+      offset: rec.resultOffset + rec.resultLength,
+      type: "close",
+      resolvedPath: rec.resolvedPath,
+      destination: rec.destination,
+    });
+  }
+  // Sort by offset; closes before opens at same offset
+  // (back-to-back inclusions: previous must close before next opens)
+  boundaries.sort((a, b) => {
+    if (a.offset !== b.offset) return a.offset - b.offset;
+    return a.type === "close" ? -1 : 1;
+  });
+  return boundaries;
+}
+
+export function mergeInclusionEvents(
+  events: Event[],
+  inclusions: InclusionRecord[]
+): Event[] {
+  if (inclusions.length === 0) return events;
+
+  const boundaries = flattenBoundaries(inclusions);
+  const opens = boundaries.filter((b) => b.type === "open");
+  const closes = boundaries.filter((b) => b.type === "close");
+
+  // Two-pass approach: first determine insertion indices, then build result.
+
+  // For opens at offset X: insert before the first event with startpos >= X
+  const openInserts: { index: number; boundary: InclusionBoundary }[] = [];
+  let oi = 0;
+  for (let i = 0; i < events.length && oi < opens.length; i++) {
+    while (oi < opens.length && opens[oi].offset <= events[i].startpos) {
+      openInserts.push({ index: i, boundary: opens[oi] });
+      oi++;
+    }
+  }
+  // Any remaining opens go at the end
+  while (oi < opens.length) {
+    openInserts.push({ index: events.length, boundary: opens[oi] });
+    oi++;
+  }
+
+  // For closes at offset X: insert after the last event where
+  // startpos < X, or (startpos == X and annot starts with "-").
+  // This ensures container close events at the boundary are included
+  // before the -inclusion marker.
+  const closeInserts: { index: number; boundary: InclusionBoundary }[] = [];
+  let ci = 0;
+  for (let i = 0; i < events.length && ci < closes.length; i++) {
+    const ev = events[i];
+    const nextEv = i + 1 < events.length ? events[i + 1] : null;
+    const closeOffset = closes[ci].offset;
+
+    // Check if this is the last event that belongs to the inclusion:
+    // The current event is within range, and either there's no next event,
+    // or the next event is beyond the boundary (starts past closeOffset),
+    // or the next event is at the boundary but is an open event (not a close).
+    const evBelongs = ev.startpos < closeOffset ||
+      (ev.startpos === closeOffset && ev.annot.startsWith("-"));
+    const nextBelongs = nextEv &&
+      (nextEv.startpos < closeOffset ||
+       (nextEv.startpos === closeOffset && nextEv.annot.startsWith("-")));
+
+    if (evBelongs && !nextBelongs) {
+      closeInserts.push({ index: i + 1, boundary: closes[ci] });
+      ci++;
+      // Check if multiple closes fire at the same position
+      while (ci < closes.length && closes[ci].offset <= closeOffset) {
+        closeInserts.push({ index: i + 1, boundary: closes[ci] });
+        ci++;
+      }
+    }
+  }
+  // Any remaining closes go at the end
+  while (ci < closes.length) {
+    closeInserts.push({ index: events.length, boundary: closes[ci] });
+    ci++;
+  }
+
+  // Merge all insertions sorted by index (opens before closes at same index,
+  // since opens at an index go before the event there and closes go after)
+  const allInserts: { index: number; event: Event }[] = [];
+  for (const o of openInserts) {
+    allInserts.push({
+      index: o.index,
+      event: {
+        startpos: o.boundary.offset,
+        endpos: o.boundary.offset,
+        annot: "+inclusion|" + o.boundary.resolvedPath,
+      },
+    });
+  }
+  for (const c of closeInserts) {
+    allInserts.push({
+      index: c.index,
+      event: {
+        startpos: c.boundary.offset,
+        endpos: c.boundary.offset,
+        annot: "-inclusion",
+      },
+    });
+  }
+  // Stable sort: by index, then by boundary offset, then closes before opens.
+  // Closes-before-opens handles back-to-back (sequential) inclusions correctly:
+  // the previous inclusion must close before the next one opens.
+  // For nested boundaries, opens and closes are always at different offsets,
+  // so this tiebreaker never applies and nesting is preserved by offset order.
+  allInserts.sort((a, b) => {
+    if (a.index !== b.index) return a.index - b.index;
+    if (a.event.startpos !== b.event.startpos) return a.event.startpos - b.event.startpos;
+    const aIsClose = a.event.annot.startsWith("-") ? 0 : 1;
+    const bIsClose = b.event.annot.startsWith("-") ? 0 : 1;
+    return aIsClose - bIsClose;
+  });
+
+  // Build result
+  const result: Event[] = [];
+  let insertIdx = 0;
+  for (let i = 0; i < events.length; i++) {
+    // Insert any synthetic events that go before this index
+    while (insertIdx < allInserts.length && allInserts[insertIdx].index === i) {
+      result.push(allInserts[insertIdx].event);
+      insertIdx++;
+    }
+    result.push(events[i]);
+  }
+  // Insert any remaining synthetic events at the end
+  while (insertIdx < allInserts.length) {
+    result.push(allInserts[insertIdx].event);
+    insertIdx++;
+  }
+
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,9 @@ export { fromPandoc, toPandoc } from "./pandoc";
 export { renderDjot } from "./djot-renderer";
 export { version } from "./version";
 export { isBlock, isInline } from "./ast";
+export { preprocessInclusions, mergeInclusionEvents, isImageFile, isBinaryContent, buildEventStreams } from "./include";
+export type { IncludeOptions } from "./options";
+export type { InclusionRecord, PreprocessResult, EventStreams } from "./include";
 
 export type {
   Alignment,

--- a/src/inline.ts
+++ b/src/inline.ts
@@ -155,6 +155,7 @@ const betweenMatched = function(
             if (linkOpener.annot === "explicit_link" &&
                 opener.startpos < linkOpener.startpos) {
               // opener is outside the link, don't match
+              self.hasUnmatchedClosers = true;
               self.addMatch(pos, endcloser, defaultmatch);
               return endcloser + 1;
             }
@@ -177,6 +178,9 @@ const betweenMatched = function(
       self.addOpener(e, startopener, pos, defaultmatch);
       return pos + 1;
     } else {
+      if (can_close) {
+        self.hasUnmatchedClosers = true;
+      }
       self.addMatch(pos, endcloser, defaultmatch);
       return endcloser + 1;
     }
@@ -554,6 +558,7 @@ class InlineParser {
   attributeStart: null | number; // start pos of potential attribute
   attributeSlices: null | { startpos: number, endpos: number }[]; // slices we've tried to parse as attributes
   matchers: Record<number, (self: InlineParser, sp: number, ep: number) => null | number>; // functions to handle different code points
+  hasUnmatchedClosers: boolean;
 
   constructor(subject: string,
               options: Options = {}) {
@@ -572,6 +577,7 @@ class InlineParser {
     this.attributeStart = null;
     this.attributeSlices = null;
     this.matchers = matchers;
+    this.hasUnmatchedClosers = false;
   }
 
   addMatch(startpos: number, endpos: number,

--- a/src/options.ts
+++ b/src/options.ts
@@ -28,9 +28,15 @@ interface Options {
   warn?: (warning : Warning) => void;
 }
 
+interface IncludeOptions {
+  readFile?: (path: string) => string | null;
+  basePath?: string;
+}
+
 export type {
   SourceLoc,
   Options,
+  IncludeOptions,
 }
 export {
   Warning,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "src/index.ts",
     "src/version.ts",
     "src/options.ts",
+    "src/include.ts",
     "src/cli.ts"
   ]
 }


### PR DESCRIPTION
Implements recursive file inclusion (a.k.a. [transclusion](https://en.m.wikipedia.org/wiki/Transclusion)) without AST nodes.
See [djot issue 307](https://github.com/jgm/djot/issues/307)

Example usage:

``` javascript
const streams = djot.buildEventStreams(djotContent, opts);
const ast = djot.parseFromEvents(streams.expandedEvents, streams.expandedText, { sourcePositions: true });
const htmlContent = djot.renderHTML(ast);
```

Example use in an application - djot editor with live preview:
(both source syntax highlighting and html rendering are done with the embedded djot.js)

<img width="1800" height="873" alt="image" src="https://github.com/user-attachments/assets/0dddc0da-2ae4-4473-8ed7-01b0e6e53daa" />


Example use of inclusion as inline and as block element:

<img width="1842" height="857" alt="image" src="https://github.com/user-attachments/assets/c5eb47f3-f908-4411-8db2-0b9123c1ace6" />
