### PR TITLE
Emit fnref id only on first reference to a footnote

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -16,6 +16,7 @@ class HTMLRenderer {
   private tight: boolean;
   footnoteIndex: Record<string, number>;
   nextFootnoteIndex: number;
+  fnrefIdEmitted: Record<string, boolean>;
   references: Record<string, Reference>;
   autoReferences: Record<string, Reference>;
 
@@ -25,6 +26,7 @@ class HTMLRenderer {
     this.tight = false;
     this.footnoteIndex = {};
     this.nextFootnoteIndex = 1;
+    this.fnrefIdEmitted = {};
     this.references = {};
     this.autoReferences = {};
   }
@@ -263,11 +265,14 @@ class HTMLRenderer {
           this.footnoteIndex[label] = index;
           this.nextFootnoteIndex++;
         }
-        result += this.renderTag("a", node, {
-          id: "fnref" + index,
-          href: "#fn" + index,
-          role: "doc-noteref"
-        });
+        const extraAttrs: Record<string, string> = {};
+        if (!this.fnrefIdEmitted[label]) {
+          extraAttrs.id = "fnref" + index;
+          this.fnrefIdEmitted[label] = true;
+        }
+        extraAttrs.href = "#fn" + index;
+        extraAttrs.role = "doc-noteref";
+        result += this.renderTag("a", node, extraAttrs);
         result += "<sup>";
         result += this.escape(index.toString());
         result += "</sup></a>";

--- a/test/footnotes.test
+++ b/test/footnotes.test
@@ -13,7 +13,7 @@ test[^a] and another[^foo_bar].
 another ref to the first note[^a].
 .
 <p>test<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a> and another<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a>.</p>
-<p>another ref to the first note<a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a>.</p>
+<p>another ref to the first note<a href="#fn1" role="doc-noteref"><sup>1</sup></a>.</p>
 <section role="doc-endnotes">
 <hr>
 <ol>
@@ -85,7 +85,7 @@ text[^footnote].
 <p>very long footnote<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a><a href="#fnref1" role="doc-backlink">↩︎</a></p>
 </li>
 <li id="fn2">
-<p>bla bla<a id="fnref2" href="#fn2" role="doc-noteref"><sup>2</sup></a><a href="#fnref2" role="doc-backlink">↩︎</a></p>
+<p>bla bla<a href="#fn2" role="doc-noteref"><sup>2</sup></a><a href="#fnref2" role="doc-backlink">↩︎</a></p>
 </li>
 </ol>
 </section>


### PR DESCRIPTION
Repeating a footnote reference (e.g. `[^a]` in two places) produced two `<a>` elements with the same `id="fnrefN"`, violating HTML5 unique id rules and leaving the endnote backlink ambiguous. Only the first call site now carries the id; subsequent references keep `href="#fnN"` but drop the duplicate id, so the single backlink resolves cleanly.