### PR TITLE
Document HTML output security considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,13 @@ djot.renderHTML(
 
 This yields: `<span class="emphasized">hi</span>`.
 
-### Security
+### A note on HTML output
 
-`renderHTML` output is not sanitized. Do not render untrusted
-djot input to HTML without downstream sanitization. In particular,
-raw HTML, attributes such as `onclick` or `srcdoc`, and unsafe URL
-schemes such as `javascript:` or `data:` can produce unsafe HTML.
-See the Security section in the
-[djot syntax reference](https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html).
+`renderHTML` output is not sanitized. When rendering untrusted djot input
+to HTML, sanitize it downstream before serving it in a browser. In
+particular, raw HTML, attributes such as `onclick` or `srcdoc`, and
+unsafe URL schemes such as `javascript:` or `data:` can produce unsafe
+HTML.
 
 ### Rendering djot
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ djot.renderHTML(
 
 This yields: `<span class="emphasized">hi</span>`.
 
+### Security
+
+`renderHTML` output is not sanitized. Do not render untrusted
+djot input to HTML without downstream sanitization. In particular,
+raw HTML, attributes such as `onclick` or `srcdoc`, and unsafe URL
+schemes such as `javascript:` or `data:` can produce unsafe HTML.
+See the Security section in the
+[djot syntax reference](https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html).
+
 ### Rendering djot
 
 `renderDjot(doc : Doc, options : DjotRenderOptions = {}) : string`


### PR DESCRIPTION
Adds a README Security note for `renderHTML`, documenting that HTML output is not sanitized and consumers rendering untrusted djot input should sanitize downstream.

This is the `djot.js` README half of jgm/djot#403. The companion syntax-reference docs PR is jgm/djot#404.

The note calls out the same main surfaces:
- raw HTML
- attributes such as `onclick` or `srcdoc`
- unsafe URL schemes such as `javascript:` or `data:`

Docs only; no runtime behavior changes.