### PR TITLE
Use tight end positions for lazily closed blocks (sourcePositions)

### DIFF
--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -197,6 +197,88 @@ describe("Parser", () => {
     );
   });
 
+  it("uses tight source position ends for lazy-closing block quotes", () => {
+    const ast = parse("> q\n\nAfter.\n", {sourcePositions: true}) as any;
+    const blockQuote = ast.children[0];
+    const para = ast.children[1];
+    expect(blockQuote.pos).toEqual({
+      "start": { "line": 1, "col": 1, "offset": 0 },
+      "end": { "line": 2, "col": 0, "offset": 3 }
+    });
+    expect(para.pos).toEqual({
+      "start": { "line": 3, "col": 1, "offset": 5 },
+      "end": { "line": 4, "col": 0, "offset": 11 }
+    });
+    expect(blockQuote.pos.end.offset).toBeLessThan(para.pos.start.offset);
+  });
+
+  it("uses tight source position ends for lazy-closing tables", () => {
+    const ast = parse("| a |\n| --- |\n| 1 |\n\nAfter.\n",
+      {sourcePositions: true}) as any;
+    const table = ast.children[0];
+    const para = ast.children[1];
+    expect(table.pos).toEqual({
+      "start": { "line": 1, "col": 1, "offset": 0 },
+      "end": { "line": 4, "col": 0, "offset": 19 }
+    });
+    expect(para.pos).toEqual({
+      "start": { "line": 5, "col": 1, "offset": 21 },
+      "end": { "line": 6, "col": 0, "offset": 27 }
+    });
+    expect(table.pos.end.offset).toBeLessThan(para.pos.start.offset);
+  });
+
+  it("uses tight source position ends for lazy-closing lists", () => {
+    const ast = parse("- a\n- b\n\nAfter.\n",
+      {sourcePositions: true}) as any;
+    const list = ast.children[0];
+    const para = ast.children[1];
+    expect(list.pos).toEqual({
+      "start": { "line": 1, "col": 1, "offset": 0 },
+      "end": { "line": 3, "col": 0, "offset": 7 }
+    });
+    expect(para.pos).toEqual({
+      "start": { "line": 4, "col": 1, "offset": 9 },
+      "end": { "line": 5, "col": 0, "offset": 15 }
+    });
+    expect(list.pos.end.offset).toBeLessThan(para.pos.start.offset);
+    // The lazily closed last item must stay contained in the list's range.
+    const lastItem = list.children[list.children.length - 1];
+    expect(lastItem.pos.end.offset).toBeLessThanOrEqual(list.pos.end.offset);
+  });
+
+  it("uses tight source position ends for lazy-closing definition lists", () => {
+    const ast = parse(": term\n  def\n\nAfter.\n",
+      {sourcePositions: true}) as any;
+    const list = ast.children[0];
+    const para = ast.children[1];
+    expect(list.pos).toEqual({
+      "start": { "line": 1, "col": 1, "offset": 0 },
+      "end": { "line": 3, "col": 0, "offset": 12 }
+    });
+    expect(para.pos).toEqual({
+      "start": { "line": 4, "col": 1, "offset": 14 },
+      "end": { "line": 5, "col": 0, "offset": 20 }
+    });
+    expect(list.pos.end.offset).toBeLessThan(para.pos.start.offset);
+  });
+
+  it("uses tight source position ends for lazy-closing footnotes", () => {
+    const ast = parse("[^a]: note\n\nAfter.\n",
+      {sourcePositions: true}) as any;
+    const footnote = ast.footnotes.a;
+    const para = ast.children[0];
+    expect(footnote.pos).toEqual({
+      "start": { "line": 1, "col": 1, "offset": 0 },
+      "end": { "line": 2, "col": 0, "offset": 10 }
+    });
+    expect(para.pos).toEqual({
+      "start": { "line": 3, "col": 1, "offset": 12 },
+      "end": { "line": 4, "col": 0, "offset": 18 }
+    });
+    expect(footnote.pos.end.offset).toBeLessThan(para.pos.start.offset);
+  });
+
   it("renders pretty", () => {
     const ast = parse("hi there\nfriend\n\nnew para\n", {sourcePositions: true});
     expect(renderAST(ast)).toEqual(

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -252,6 +252,53 @@ const parseFromEvents = function(events: Event[],
     }
   }
 
+  const getLastChildEnd = function(node: Container): SourceLoc | undefined {
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      const child = node.children[i];
+      if (child.pos) {
+        return child.pos.end;
+      }
+    }
+    return undefined;
+  }
+
+  const getLastBlockEnd = function(node: Container | AstNode):
+      SourceLoc | undefined {
+    if ("children" in node) {
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        const child = node.children[i];
+        if ("tag" in child && isBlock(child) && child.pos) {
+          return child.pos.end;
+        }
+        const end = getLastBlockEnd(child);
+        if (end) {
+          return end;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  const tightenContainerEnd = function(node: Container): void {
+    if (!node.pos) {
+      return;
+    }
+    const end = getLastChildEnd(node);
+    if (end) {
+      node.pos.end = end;
+    }
+  }
+
+  const tightenListEnd = function(node: Container): void {
+    if (!node.pos) {
+      return;
+    }
+    const end = getLastBlockEnd(node);
+    if (end) {
+      node.pos.end = end;
+    }
+  }
+
 
   const handlers : Record<string, (suffixes : string[],
                                    startpos : number,
@@ -812,6 +859,11 @@ const parseFromEvents = function(events: Event[],
         if (!listStyle) {
           throw (new Error("No style defined for list"));
         }
+        if (listStyle === ":") {
+          tightenContainerEnd(node);
+        } else {
+          tightenListEnd(node);
+        }
         const listStart = getListStart(node.data.firstMarker, listStyle);
         if (listStyle === ":") {
           addChildToTip({
@@ -869,6 +921,10 @@ const parseFromEvents = function(events: Event[],
 
       ["-list_item"]: (suffixes, startpos, endpos, pos) => {
         const node = popContainer(pos);
+        // A lazily closed item (e.g. before a blank line that ends the list)
+        // must not extend past its own content, so the parent list's
+        // tightened range still contains it.
+        tightenContainerEnd(node);
         if (node.data.definitionList) {
           if (node.children[0] && node.children[0].tag === "para") {
             const term: Term =
@@ -934,6 +990,7 @@ const parseFromEvents = function(events: Event[],
 
       ["-block_quote"]: (suffixes, startpos, endpos, pos) => {
         const node = popContainer(pos);
+        tightenContainerEnd(node);
         addChildToTip({
           tag: "block_quote",
           children: node.children,
@@ -949,6 +1006,7 @@ const parseFromEvents = function(events: Event[],
 
       ["-table"]: (suffixes, startpos, endpos, pos) => {
         const node = popContainer(pos);
+        tightenContainerEnd(node);
         const rows = node.children;
         let caption: Caption = {
           tag: "caption",
@@ -1059,6 +1117,7 @@ const parseFromEvents = function(events: Event[],
 
       ["-footnote"]: (suffixes, startpos, endpos, pos) => {
         const node = popContainer(pos);
+        tightenContainerEnd(node);
         if (node.data.label) {
           const lab = normalizeLabel(node.data.label);
           footnotes[lab] =

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -252,50 +252,10 @@ const parseFromEvents = function(events: Event[],
     }
   }
 
-  const getLastChildEnd = function(node: Container): SourceLoc | undefined {
-    for (let i = node.children.length - 1; i >= 0; i--) {
-      const child = node.children[i];
-      if (child.pos) {
-        return child.pos.end;
-      }
-    }
-    return undefined;
-  }
-
-  const getLastBlockEnd = function(node: Container | AstNode):
-      SourceLoc | undefined {
-    if ("children" in node) {
-      for (let i = node.children.length - 1; i >= 0; i--) {
-        const child = node.children[i];
-        if ("tag" in child && isBlock(child) && child.pos) {
-          return child.pos.end;
-        }
-        const end = getLastBlockEnd(child);
-        if (end) {
-          return end;
-        }
-      }
-    }
-    return undefined;
-  }
-
   const tightenContainerEnd = function(node: Container): void {
-    if (!node.pos) {
-      return;
-    }
-    const end = getLastChildEnd(node);
-    if (end) {
-      node.pos.end = end;
-    }
-  }
-
-  const tightenListEnd = function(node: Container): void {
-    if (!node.pos) {
-      return;
-    }
-    const end = getLastBlockEnd(node);
-    if (end) {
-      node.pos.end = end;
+    const lastChild = node.children[node.children.length - 1];
+    if (node.pos && lastChild && lastChild.pos) {
+      node.pos.end = lastChild.pos.end;
     }
   }
 
@@ -859,11 +819,7 @@ const parseFromEvents = function(events: Event[],
         if (!listStyle) {
           throw (new Error("No style defined for list"));
         }
-        if (listStyle === ":") {
-          tightenContainerEnd(node);
-        } else {
-          tightenListEnd(node);
-        }
+        tightenContainerEnd(node);
         const listStart = getListStart(node.data.firstMarker, listStyle);
         if (listStyle === ":") {
           addChildToTip({

--- a/test/sourcepos.test
+++ b/test/sourcepos.test
@@ -4,7 +4,7 @@
 .
 doc
   bullet_list (1:2:1-3:0:9) tight=true style="-"
-    list_item (1:2:1-2:1:5)
+    list_item (1:2:1-2:0:4)
       para (1:4:3-2:0:4)
         str (1:4:3-1:4:3) text="a"
     list_item (2:2:6-3:0:9)


### PR DESCRIPTION
Fixes #141.

With `sourcePositions: true`, blocks that close lazily when the parser recognizes the following construct (lists, tables, block quotes, definition lists, footnotes) reported `pos.end` from the parse offset at close time. That included the separator blank line, and for lists the end could equal the next sibling's start:

```js
parse("- a\n- b\n\nAfter.\n", {sourcePositions: true})
// before: bullet_list end = 4:1:9, identical to the following para's start
// after:  bullet_list end = 3:0:7
```

This change tightens those containers to end at their last child's end position - the convention paragraphs and code fences already follow (paragraph `"One.\n"` ends at `2:0:4`, its trailing newline). Separator blank lines now belong to no block, and sibling ranges no longer overlap. List items are tightened as well, so a parent list's range always contains its last item (previously the tightened list could end before the lazily closed item).

Same approach as the earlier end-position fixes in #83 (list_item) and #82 (section); those behaviors are unchanged.

Tests: new cases in `src/parse.spec.ts` assert exact start/end for block quote, table, bullet list, definition list, and footnote, plus the following paragraph's positions and non-overlap/containment. One expectation in `test/sourcepos.test` encoded the old overshoot (`list_item (1:2:1-2:1:5)` - ending at the first character of the next item's line) and was updated to the tight value. Full suite passes.
