### PR TITLE
Make bracketed span conditional on valid attributes

### DIFF
--- a/src/inline.ts
+++ b/src/inline.ts
@@ -430,6 +430,12 @@ const matchers = {
         self.addMatch(opener.startpos, opener.endpos, "+span",
                       opener.matchIndex);
         self.addMatch(pos, pos, "-span");
+        if (self.allowAttributes) {
+          // speculative: revert to literal brackets if the attribute
+          // parse that must follow fails
+          self.pendingSpan = { openMatchIndex: opener.matchIndex,
+                               closeMatchIndex: self.matches.length - 1 };
+        }
         // remove any openers between [ and ]
         self.clearOpeners(opener.startpos, pos);
         return pos + 1;
@@ -562,6 +568,7 @@ class InlineParser {
   attributeParser: null | AttributeParser; // attribute parser
   attributeStart: null | number; // start pos of potential attribute
   attributeSlices: null | { startpos: number, endpos: number }[]; // slices we've tried to parse as attributes
+  pendingSpan: null | { openMatchIndex: number, closeMatchIndex: number }; // span awaiting attribute confirmation
   matchers: Record<number, (self: InlineParser, sp: number, ep: number) => null | number>; // functions to handle different code points
 
   constructor(subject: string,
@@ -580,6 +587,7 @@ class InlineParser {
     this.attributeParser = null;
     this.attributeStart = null;
     this.attributeSlices = null;
+    this.pendingSpan = null;
     this.matchers = matchers;
   }
 
@@ -631,6 +639,14 @@ class InlineParser {
     const slices = this.attributeSlices;
     if (slices === null) {
       return;
+    }
+    const pendingSpan = this.pendingSpan;
+    if (pendingSpan) {
+      // a span is only a span when followed by a valid attribute;
+      // make the brackets literal again
+      this.matches[pendingSpan.openMatchIndex].annot = "str";
+      this.matches[pendingSpan.closeMatchIndex].annot = "str";
+      this.pendingSpan = null;
     }
     this.allowAttributes = false;
     this.attributeParser = null;
@@ -778,6 +794,7 @@ class InlineParser {
           this.attributeParser = null;
           this.attributeStart = null;
           this.attributeSlices = null;
+          this.pendingSpan = null;
           pos = ep + 1;
         } else if (result.status === "fail") {
           this.reparseAttributes();

--- a/test/spans.test
+++ b/test/spans.test
@@ -17,3 +17,21 @@ not a [span] {#id}.
 .
 <p><span id="ident">nested <span class="blue">span</span></span></p>
 ```
+
+```
+[not a span]{#a<b}
+.
+<p>[not a span]{#a&lt;b}</p>
+```
+
+```
+[*not* a span]{#a<b}
+.
+<p>[<strong>not</strong> a span]{#a&lt;b}</p>
+```
+
+```
+[not a span]{#a
+.
+<p>[not a span]{#a</p>
+```


### PR DESCRIPTION
Follow-up to the discussion in #137: per the docs, "Text in square brackets that is not a link or image *and is followed immediately by an attribute* is treated as a generic span." The parser committed the span matches as soon as it saw `[...]{`, so when the attribute parse subsequently failed (or ran into end of input), the braces were reparsed as literal text but the span itself remained:

```
[x]{#a<b}
```

rendered as

```html
<p><span>x</span>{#a&lt;b}</p>
```

With this change the span is tracked as speculative and its open/close matches are reverted to literal brackets when the attribute parse fails, so the whole construct stays literal:

```html
<p>[x]{#a&lt;b}</p>
```

Inline content between the brackets is still parsed normally (`[*x*]{#a<b}` gives `[<strong>x</strong>]{#a&lt;b}`), and the end-of-input case (`[x]{#a`) is covered via the same reparse path. Valid attributes are unaffected.

Tests: three new cases in `test/spans.test` (invalid attribute, invalid attribute with inline formatting, unterminated attribute at end of input). Full suite passes.

Also resolves the discussed bug in https://github.com/jgm/djot/issues/399 here.
