### PR TITLE
Keep an explicit quote marker from rewriting the shared default.

### DIFF
--- a/src/inline.ts
+++ b/src/inline.ts
@@ -129,10 +129,13 @@ const betweenMatched = function(
       endcloser = pos + 1;
     }
 
-    if (has_open_marker && defaultmatch.match(/^right/)) {
-      defaultmatch = defaultmatch.replace(/^right/, "left");
-    } else if (has_close_marker && defaultmatch.match(/^left/)) {
-      defaultmatch = defaultmatch.replace(/^left/, "right");
+    // NB. assigning to `defaultmatch` here would outlive the call: it is
+    // captured from betweenMatched, and the matchers table is built once.
+    let match = defaultmatch;
+    if (has_open_marker && match.match(/^right/)) {
+      match = match.replace(/^right/, "left");
+    } else if (has_close_marker && match.match(/^left/)) {
+      match = match.replace(/^left/, "right");
     }
 
     let d = c;
@@ -154,7 +157,7 @@ const betweenMatched = function(
             if (linkOpener.annot === "explicit_link" &&
                 opener.startpos < linkOpener.startpos) {
               // opener is outside the link, don't match
-              self.addMatch(pos, endcloser, defaultmatch);
+              self.addMatch(pos, endcloser, match);
               return endcloser + 1;
             }
           }
@@ -173,10 +176,10 @@ const betweenMatched = function(
       if (has_open_marker) {
         e = "{" + e;
       }
-      self.addOpener(e, startopener, pos, defaultmatch);
+      self.addOpener(e, startopener, pos, match);
       return pos + 1;
     } else {
-      self.addMatch(pos, endcloser, defaultmatch);
+      self.addMatch(pos, endcloser, match);
       return endcloser + 1;
     }
   }

--- a/test/smart.test
+++ b/test/smart.test
@@ -190,3 +190,16 @@ No ellipses\.\.\.
 .
 <p>No ellipses...</p>
 ```
+
+An explicit `"}` closer applies only to its own quote. It must not
+change how later unmatched double quotes render -- an unmatched `"`
+is a left quote:
+
+```
+He said "hello"}
+
+Later an unmatched "quote here.
+.
+<p>He said “hello”</p>
+<p>Later an unmatched “quote here.</p>
+```


### PR DESCRIPTION
`defaultmatch` is a parameter of the outer betweenMatched factory, captured by the matcher it returns. The matcher assigned to it when adjusting for an explicit `{` or `}` marker, but the matchers table is built once at module load, so that binding lives for the lifetime of the module and the rewrite stuck.

One `"}` therefore flipped left_double_quote to right_double_quote for every later unmatched `"` -- in the rest of that document, and in every document parsed afterwards in the same process:

    He said "hello"}

    Later an unmatched "quote here.

rendered the second paragraph's quote as `”`, though it is unmatched and renders as `“` when that paragraph is parsed on its own. `{'` does the same in the other direction, turning later unmatched `'` into `‘`.

Only the quote matchers were affected; every other betweenMatched caller passes "str", which matches neither /^right/ nor /^left/.

Hoist the adjustment into a local so it applies only to the delimiter being handled.