### PR TITLE
Add test cases for quote pairing and footnote label normalization

### DIFF
--- a/test/footnotes.test
+++ b/test/footnotes.test
@@ -130,3 +130,22 @@ foo</p>
 </ol>
 </section>
 ```
+
+Definition labels are normalized too, so a wider gap in the definition
+still matches the reference:
+
+```
+[^a b]
+
+[^a  b]: foo
+.
+<p><a id="fnref1" href="#fn1" role="doc-noteref"><sup>1</sup></a></p>
+<section role="doc-endnotes">
+<hr>
+<ol>
+<li id="fn1">
+<p>foo<a href="#fnref1" role="doc-backlink">↩︎</a></p>
+</li>
+</ol>
+</section>
+```

--- a/test/smart.test
+++ b/test/smart.test
@@ -106,6 +106,21 @@ Doubled quotes are treated as nested:
 <p>‘‘hi’’</p>
 ```
 
+With nothing between them there is nothing to enclose, so they don't
+pair and each takes its unmatched form:
+
+```
+''
+.
+<p>’’</p>
+```
+
+```
+""
+.
+<p>““</p>
+```
+
 Heuristics for determining openers and closers can
 be overridden using `{` and `}`:
 


### PR DESCRIPTION
footnotes.test covers label normalization on the reference side (a label spanning lines). The definition side normalizes too, so a wider gap there still matches the reference; that half was untested.

smart.test has `''hi''` for doubled quotes as nested, but nothing for a doubled quote with an empty span. Adjacent delimiters enclose nothing, so they don't pair and each falls back to its unmatched form: a right quote for `'`, a left one for `"`.