### PR TITLE
Add test cases for attribute specs that fail on grammar

### DIFF
--- a/test/attributes.test
+++ b/test/attributes.test
@@ -373,6 +373,34 @@ text{a=x
 <p>{a=“ inline text</p>
 ```
 
+The cases in this section so far all fail for want of a closing brace.
+A terminated `{...}` is rejected too when its contents aren't
+attributes: `=` must be followed by a value, and a bare one cannot be
+empty (a quoted `key=""` is fine).
+
+```
+[x]{key}
+.
+<p>[x]{key}</p>
+```
+
+```
+[y]{key=}
+.
+<p>[y]{key=}</p>
+```
+
+Nothing in a rejected block is applied, so `.a` is not a class here and
+the line below stays a paragraph:
+
+```
+{.a key}
+# not a heading
+.
+<p>{.a key}
+# not a heading</p>
+```
+
 
 ``` a
 {


### PR DESCRIPTION
The "Non-attributes" cases all fail for want of a closing brace, and the terminated specs that are rejected elsewhere -- {#a<b} above, and spans.test's [not a span]{#a<b} -- fail on an invalid character in a name. A spec that is terminated and whose characters are all legal, but whose contents aren't attributes, is a third way to fail: it leaves SCANNING_KEY or SCANNING_VALUE with no value to take. That path isn't covered.

A bare key has no `=` at all; `key=` has one with nothing after it. Note the emptiness is what a *bare* value can't be -- `{key=""}` is accepted and yields key="" -- so `{key=}` is the case that pins it.

The block form is here for the same reason as the `{a=x` + "# non-heading" case above it, plus one thing that case can't show: a spec holding a valid attribute alongside an invalid one applies neither, so `.a` is not a class and the heading below stays literal.