### PR TITLE
Close fenced div on CRLF input (fixes #113)

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -642,7 +642,7 @@ class EventParser {
             if (colons.length >= container.extra.colons) {
               container.extra.endFenceStartpos = m.startpos;
               container.extra.endFenceEndpos = m.startpos + colons.length - 1;
-              this.pos = m.endpos; // before newline
+              this.pos = this.starteol; // before newline (CRLF-safe, see #113)
               return false;
             }
           }

--- a/src/html.spec.ts
+++ b/src/html.spec.ts
@@ -36,4 +36,19 @@ rendering the light markup format <a href="https://djot.net">djot</a>.</p>
     );
   });
 
+  it("closes a fenced div with CRLF line endings", () => {
+    // Regression test for issue #113: with CRLF line endings the closing
+    // ::: fence must close the div, so following content ("after") lands
+    // outside the div rather than being swallowed inside an unclosed div.
+    const expected =
+`<div>
+<p>hello</p>
+</div>
+<p>after</p>
+`;
+    expect(renderHTML(parse(":::\r\nhello\r\n:::\r\nafter\r\n"))).toEqual(expected);
+    // The LF equivalent is unchanged and produces byte-identical HTML.
+    expect(renderHTML(parse(":::\nhello\n:::\nafter\n"))).toEqual(expected);
+  });
+
 });


### PR DESCRIPTION
Fixes #113.

## Problem
With CRLF line endings, a fenced div's closing `:::` fence is not detected, so the div never closes and all following content is swallowed inside it.

    renderHTML(parse(":::\r\nhello\r\n:::\r\nafter\r\n"))

Buggy CRLF output ("after" trapped inside an unclosed div):

    <div>
    <p>hello

    after</p>
    </div>

Correct output (the LF equivalent already produces this):

    <div>
    <p>hello</p>
    </div>
    <p>after</p>

## Root cause
In the `fenced_div` `continue` callback (`src/block.ts`), when the closing fence matches, the parser sets `this.pos = m.endpos`. The fence pattern `(::::*)[ \t]*\r?\n` matches through the `\n`, so on CRLF input `m.endpos` lands on the `\n` -- one position past the `\r` that `getEol()` records as `starteol`. The main loop then evaluates the blank-line check `isBlank = (pos === starteol)` as false, so the fence line is mistaken for a lazy paragraph continuation and the div is never closed. On LF input `m.endpos` and `starteol` coincide, so the check passes and it works by coincidence.

## Fix
Set `this.pos = this.starteol`, the position just before the line ending, which is correct for both LF and CRLF. This mirrors the sibling `code_block` close path and djot.js's `\r?\n` CRLF handling throughout the lexer. LF output is byte-identical; CRLF now closes the div correctly.

## Tests
Added a regression test in `src/html.spec.ts` asserting the CRLF input closes the div (byte-identical to the LF output, which is also asserted unchanged). All existing tests pass (tsc + jest, 417 total).

Thanks to @iorizu for the clear report.

---
This change was prepared with AI assistance and reviewed by me before submission.