### PR TITLE
Warn on unattached attribute at start of inline content

### DIFF
--- a/src/parse.spec.ts
+++ b/src/parse.spec.ts
@@ -292,6 +292,12 @@ describe("Parser", () => {
 `);
   });
 
+  it("warns for unattached attributes at the start of a paragraph", () => {
+    const warnings : string[] = [];
+    parse("{.a} foo\n", {warn: (w) => warnings.push(w.render())});
+    expect(warnings).toEqual(["Ignoring unattached attribute at offset 3"]);
+  });
+
 
 
 });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -449,9 +449,14 @@ const parseFromEvents = function(events: Event[],
           if (node.attributes.id) {
             identifiers[node.attributes.id] = true;
           }
+          const warnUnattached = () =>
+            warn(new Warning("Ignoring unattached attribute",
+                          options.sourcePositions ?
+                            getSourceLoc(startpos) : startpos));
           let tip = getTip();
           if (tip === topContainer()) {
             // no inline children to add the attribute to...
+            warnUnattached();
             return;
           }
           let endsWithSpace = false;
@@ -485,9 +490,7 @@ const parseFromEvents = function(events: Event[],
           }
           tip = getTip(); // get new tip, which may be the new element
           if (endsWithSpace) {
-            warn(new Warning("Ignoring unattached attribute",
-                          options.sourcePositions ?
-                            getSourceLoc(startpos) : startpos));
+            warnUnattached();
             return;
           }
           if (!tip.attributes) {


### PR DESCRIPTION
An attribute spec with nothing to attach to is discarded, but only the mid-line case warned:

    foo {.a} bar  → warning
    {.a} foo      → no warning

Warn in the early-return branch too. HTML output unchanged.

Alternatively the text could be preserved as literal. Either way, dropping it silently doesn't look intentional.