### PR TITLE
Add test cases for lazy continuation edge cases

### DIFF
--- a/test/block_quote.test
+++ b/test/block_quote.test
@@ -82,6 +82,19 @@ lazy</p>
 </blockquote>
 ```
 
+A quoted line that opens a block of its own leaves nothing for a
+later line to continue:
+
+```
+> ***
+lazy
+.
+<blockquote>
+<hr>
+</blockquote>
+<p>lazy</p>
+```
+
 ```
 > nested
 >

--- a/test/lists.test
+++ b/test/lists.test
@@ -181,6 +181,65 @@ two
 </ul>
 ```
 
+A line that opens a block is not lazy. The container is looked for
+before the line is asked whether it continues the paragraph, so the
+block wins and the item ends:
+
+```
+- one
+> q
+.
+<ul>
+<li>
+one
+</li>
+</ul>
+<blockquote>
+<p>q</p>
+</blockquote>
+```
+
+Lazy continuation continues a paragraph. An item whose marker line is
+bare has none, so the next unindented line ends the list; an indented
+one is still the item's content:
+
+```
+-
+next
+
+-
+  next
+.
+<ul>
+<li>
+</li>
+</ul>
+<p>next</p>
+<ul>
+<li>
+next
+</li>
+</ul>
+```
+
+A paragraph opened after a blank line inside the item takes lazy
+continuation like the first one:
+
+```
+- a
+
+  b
+next
+.
+<ul>
+<li>
+<p>a</p>
+<p>b
+next</p>
+</li>
+</ul>
+```
+
 ```
 - a
 - b


### PR DESCRIPTION
lists.test:168 and block_quote.test's lazy cases all put a plain word on the lazy line, and every item or quoted line they continue is a paragraph with content. That leaves the edges of the rule untested: a lazy line that opens a block of its own, an item with nothing to continue, a paragraph opened after a blank inside the item, and a quoted line that is not a paragraph.