### PR TITLE
Add test cases for list markers and tightness

### DIFF
--- a/test/lists.test
+++ b/test/lists.test
@@ -165,6 +165,76 @@ b
 </ul>
 ```
 
+Blank lines at the end of a nested list do not count against the list
+around it, so the outer list here stays tight:
+
+```
+- one
+
+  - sub
+    more
+
+- two
+.
+<ul>
+<li>
+one
+<ul>
+<li>
+sub
+more
+</li>
+</ul>
+</li>
+<li>
+two
+</li>
+</ul>
+```
+
+Tightness is a property of each list, so a loose list nests inside a
+tight one:
+
+```
+- x
+
+  - a
+
+    b
+.
+<ul>
+<li>
+x
+<ul>
+<li>
+<p>a</p>
+<p>b</p>
+</li>
+</ul>
+</li>
+</ul>
+```
+
+A tight item still holds blocks, so one that opens with a fence is
+not a paragraph of literal text:
+
+```
+- ~~~
+  x
+  ~~~
+- b
+.
+<ul>
+<li>
+<pre><code>x
+</code></pre>
+</li>
+<li>
+b
+</li>
+</ul>
+```
+
 ```
 - one
 lazy
@@ -199,6 +269,32 @@ b
 c
 </li>
 </ul>
+```
+
+The same for an ordered list, where the blank line after `a.` is not
+between two of the first list's items and does not loosen it:
+
+```
+1. A
+a. B
+
+1) C
+.
+<ol>
+<li>
+A
+</li>
+</ol>
+<ol type="a">
+<li>
+B
+</li>
+</ol>
+<ol>
+<li>
+C
+</li>
+</ol>
 ```
 
 ```
@@ -565,6 +661,39 @@ a
 </li>
 <li>
 b
+</li>
+</ol>
+```
+
+That holds for a list of one item too:
+
+```
+i. one
+.
+<ol type="i">
+<li>
+one
+</li>
+</ol>
+```
+
+Every item narrows the readings, not only the second, so a later item
+can still settle an ambiguity the earlier ones left open:
+
+```
+i. a
+v. b
+j. c
+.
+<ol start="9" type="a">
+<li>
+a
+</li>
+<li>
+b
+</li>
+<li>
+c
 </li>
 </ol>
 ```

--- a/test/task_lists.test
+++ b/test/task_lists.test
@@ -59,3 +59,36 @@ baz
 </li>
 </ul>
 ```
+
+A task marker is its own list style, so a task item and a plain one
+never continue each other's list:
+
+```
+- a
+- [ ] x
+.
+<ul>
+<li>
+a
+</li>
+</ul>
+<ul class="task-list">
+<li>
+<input disabled="" type="checkbox"/>
+x
+</li>
+</ul>
+```
+
+The box takes an upper-case `X` as well as a lower-case one:
+
+```
+- [X] y
+.
+<ul class="task-list">
+<li>
+<input disabled="" type="checkbox" checked=""/>
+y
+</li>
+</ul>
+```


### PR DESCRIPTION
task_lists.test separates lists by bullet character but never mixes a task marker with a plain one, and writes every box lower-case. lists.test ends a list at a bullet of another kind but not at an ordered marker of another kind, so the blank line after that marker is never asked whether it loosens the list. Its ambiguous-marker cases resolve on the second item or stay ambiguous, so neither a one-item `i.` list nor an item after the second deciding is covered.

The tightness cases pin two sentences of the spec -- blank lines at the end of a nested list do not count, and tightness is per list -- and that a tight item is still a container of blocks.

---

As with most of my test cases, these are cases an LLM got wrong when implementing a djot->HTML converter. Just let me know when you think the cases get too niche and bloat the test suite. I have a backlog of potentially upstreamable cases and only collect a few of them for a PR from time to time.